### PR TITLE
Fix oni calls crashing when no acquisition board is present

### DIFF
--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -77,14 +77,14 @@ bool AcqBoardONI::detectBoard()
     LOGC ("Searching for ONI Acquisition Board...");
     const oni_driver_info_t* driverInfo;
     int return_code = evalBoard->open (&driverInfo);
-
-    int major, minor, patch;
-    evalBoard->getONIVersion (&major, &minor, &patch);
-    LOGC ("ONI Library version: ", major, ".", minor, ".", patch);
-    LOGC ("ONI Driver: ", driverInfo->name, " Version: ", driverInfo->major, ".", driverInfo->minor, ".", driverInfo->patch, (driverInfo->pre_release ? "-" : ""), (driverInfo->pre_release ? driverInfo->pre_release : ""));
+       
 
     if (return_code == 1) // successfully opened board
     {
+        int major, minor, patch;
+        evalBoard->getONIVersion (&major, &minor, &patch);
+        LOGC ("ONI Library version: ", major, ".", minor, ".", patch);
+        LOGC ("ONI Driver: ", driverInfo->name, " Version: ", driverInfo->major, ".", driverInfo->minor, ".", driverInfo->patch, (driverInfo->pre_release ? "-" : ""), (driverInfo->pre_release ? driverInfo->pre_release : ""));
         if (evalBoard->getFTDriverInfo (&major, &minor, &patch))
         {
             LOGC ("FTDI Driver version: ", major, ".", minor, ".", patch);

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -36,10 +36,11 @@ bool Rhd2000ONIBoard::isUSB3()
 int Rhd2000ONIBoard::open (const oni_driver_info_t** driverInfo)
 {
     ctx = oni_create_ctx ("ft600"); // "ft600" is the driver name for the usb
-    if (driverInfo)
-        getONIDriverInfo (driverInfo);
     if (ctx == NULL)
         return -1;
+    if (driverInfo)
+        getONIDriverInfo (driverInfo);
+    
 
     if (oni_init_ctx (ctx, -1) != ONI_ESUCCESS)
     {


### PR DESCRIPTION
If no board is present, the current operation order causes a crash as they are trying to access ONI functions without a working context. this moves the order of operations so these calls are only made if a proper context is available.,