### PR TITLE
Prevent crashes if no board is detected

### DIFF
--- a/Source/DeviceEditor.cpp
+++ b/Source/DeviceEditor.cpp
@@ -44,6 +44,20 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
       board (board_)
 {
     canvas = nullptr;
+    noBoardsDetectedLabel = nullptr;
+
+    if (board == nullptr)
+    {
+        noBoardsDetectedLabel = std::make_unique<Label> ("NoBoardsDetected", "No Boards Detected.");
+        noBoardsDetectedLabel->setBounds (0, 15, 340, 125);
+        noBoardsDetectedLabel->setAlwaysOnTop (true);
+        noBoardsDetectedLabel->toFront(false);
+        noBoardsDetectedLabel->setJustificationType (Justification::centred);
+        noBoardsDetectedLabel->setColour(Label::textColourId, Colours::black);
+        addAndMakeVisible (noBoardsDetectedLabel.get());
+
+        return;
+    }
 
     // add headstage-specific controls (currently just a toggle button)
     for (int i = 0; i < 4; i++)
@@ -362,6 +376,11 @@ void DeviceEditor::stopAcquisition()
 
 void DeviceEditor::saveVisualizerEditorParameters (XmlElement* xml)
 {
+    if (board == nullptr)
+    {
+        return;
+    }
+
     xml->setAttribute ("SampleRate", sampleRateInterface->getSelectedId());
     xml->setAttribute ("SampleRateString", sampleRateInterface->getText());
     xml->setAttribute ("LowCut", bandwidthInterface->getLowerBandwidth());
@@ -440,6 +459,11 @@ void DeviceEditor::loadVisualizerEditorParameters (XmlElement* xml)
 Visualizer* DeviceEditor::createNewCanvas()
 {
     GenericProcessor* processor = (GenericProcessor*) getProcessor();
+
+    if (board == nullptr)
+    {
+        return nullptr;
+    }
 
     canvas = new ChannelCanvas (board, this);
 

--- a/Source/DeviceEditor.h
+++ b/Source/DeviceEditor.h
@@ -113,6 +113,7 @@ private:
     ScopedPointer<ComboBox> ttlSettleCombo, dacHPFcombo;
 
     ScopedPointer<Label> audioLabel, ttlSettleLabel, dacHPFlabel;
+    std::unique_ptr<Label> noBoardsDetectedLabel;
 
     enum AudioChannel
     {


### PR DESCRIPTION
- This presents a blank canvas and an editor that only states "No boards detected" if the user presses "No" with no boards connected
- Fixes #2 

This PR is slightly modeled after how the Neuropixels-PXI plugin handles the user pressing No if no hardware is connected. Namely, it skips the initialization steps that were previously crashing, and instead presents a mostly blank editor and a blank canvas that cannot perform any actions. 

I could not figure out how to prevent the canvas from being automatically opened, so if anyone has any recommendations on how to do that it would be greatly appreciated!