### PR TITLE
Initialize DAC trigger thresholds to zero

### DIFF
--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -49,7 +49,7 @@ AcqBoardONI::AcqBoardONI (DataBuffer* buffer_) : AcquisitionBoard (buffer_),
         dacStream.add(0);
         setDACTriggerThreshold (k, 65534);
         dacChannels.add(0);
-        dacThresholds.add(0);
+        dacThresholds.set(k, 0);
     }
 }
 

--- a/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
+++ b/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
@@ -59,7 +59,7 @@ AcqBoardOpalKelly::AcqBoardOpalKelly (DataBuffer* buffer_) : AcquisitionBoard (b
         dacStream.add (0);
         setDACTriggerThreshold (k, 65534);
         dacChannels.add (0);
-        dacThresholds.add (0);
+        dacThresholds.set (k, 0);
     }
 }
 


### PR DESCRIPTION
- Fixes #3 

During initialization, instead of being initialized to zero the DAC thresholds were set to 65534, which led to them overflowing when trying to set the threshold. Now, the thresholds are set to zero.