### PR TITLE
Update error messages when checking memory status

### DIFF
--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -63,11 +63,29 @@ bool AcqBoardONI::checkBoardMem() const
 {
     Rhd2000ONIBoard::BoardMemState memState;
     memState = evalBoard->getBoardMemState();
-    if (memState == Rhd2000ONIBoard::BOARDMEM_INVALID)
-        return true; //Firmware does not report memory status
-    if (memState == Rhd2000ONIBoard::BOARDMEM_OK)
+
+    if (memState == Rhd2000ONIBoard::BOARDMEM_INIT)
+    {
+        LOGD ("Memory is still initializing, wait before retrying this operation.");
+        CoreServices::sendStatusMessage ("Acquisition Board: Please wait, memory initializing.");
+        return false;
+    }
+    else if (memState == Rhd2000ONIBoard::BOARDMEM_ERR)
+    {
+        LOGE ("On-board memory error. Try closing the GUI, un-plugging the board from power and usb and plugging everything again. If the problem persists please contact support.");
+        CoreServices::sendStatusMessage ("Acquisition Board: Memory error.");
+        return false;
+    }
+    else if (memState == Rhd2000ONIBoard::BOARDMEM_INVALID)
+    {
+        LOGE ("Invalid memory operation.");
+        CoreServices::sendStatusMessage ("Acquisition Board: Invalid memory operation.");
+        return false;
+    }
+    else if (memState == Rhd2000ONIBoard::BOARDMEM_OK)
         return true;
-    LOGE ("On-board memory error. Try again after 30 seconds or after closing the GUI, un-plugging the board from power and usb and plugging everything again. If the problem persists please contact support");
+
+    LOGD ("Unknown memory state. Board returned ", memState);
     return false;
 }
 


### PR DESCRIPTION
- Fixes #5 

Explicitly check when memory is initializing, and output an error message that cautions the user to wait before trying again. This ensures that if the user tries to scan the port or start acquisition they will get a message indicating why the operation didn't work. This is printed to the MessageCenter as well as the debug console.