### PR TITLE
Add background initialization thread for ONI Acquisition Board

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ if(MSVC)
 	target_compile_options(${PLUGIN_NAME} PRIVATE /sdl- /W0)
 	
 	install(TARGETS ${PLUGIN_NAME} RUNTIME DESTINATION ${GUI_BIN_DIR}/plugins  CONFIGURATIONS ${CMAKE_CONFIGURATION_TYPES})
+	install(FILES $<TARGET_PDB_FILE:${PLUGIN_NAME}> DESTINATION ${GUI_BIN_DIR}/plugins OPTIONAL)
 
 elseif(LINUX)
 	target_link_libraries(${PLUGIN_NAME} GL X11 Xext Xinerama asound dl freetype pthread rt)

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "0.1.0";
+	info->libVersion = "0.1.1";
 	info->numPlugins = NUM_PLUGINS;
 }
 

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -125,11 +125,27 @@ bool AcqBoardONI::detectBoard()
         {
             LOGC ("No ONI Acquisition Board found.");
         }
+        deviceFound = false;
         return false;
     }
 }
 
+
+void InitializerThread::run()
+{
+    setProgress(-1.0); // Show an indeterminate progress bar
+    board->initializeBoardInThread();
+}
+
 bool AcqBoardONI::initializeBoard()
+{
+    InitializerThread initializer(this);
+    initializer.runThread();
+
+    return true;
+}
+
+bool AcqBoardONI::initializeBoardInThread()
 {
     LOGC ("Initializing ONI Acquisition Board...");
 

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -42,19 +42,44 @@
 
 #define MAX_NUM_CHANNELS MAX_NUM_DATA_STREAMS_USB3 * 35 + 16
 
+/**
+    Background thread with progress window for scanning ports
+*/
 class PortScanner : public ThreadWithProgressWindow
 {
 public:
-    PortScanner(AcqBoardONI* board_) : 
-        ThreadWithProgressWindow("Scanning ports...", true, false), board(board_)
+    PortScanner (AcqBoardONI* board_) : ThreadWithProgressWindow ("Scanning ports...", true, false), board (board_)
     {
-	}
+    }
 
     ~PortScanner()
     {
-		signalThreadShouldExit();
-		waitForThreadToExit(1000);
-	}
+        signalThreadShouldExit();
+        waitForThreadToExit (1000);
+    }
+
+    void run() override;
+
+private:
+    AcqBoardONI* board;
+};
+
+/**
+    Background thread with progress window for initializing the board
+*/
+class InitializerThread : public juce::ThreadWithProgressWindow
+{
+public:
+    InitializerThread (AcqBoardONI* board_)
+        : ThreadWithProgressWindow ("Initializing ONI Acquisition Board...", true, false), board (board_)
+    {
+    }
+
+    ~InitializerThread()
+    {
+        signalThreadShouldExit();
+        waitForThreadToExit (1000);
+    }
 
     void run() override;
 
@@ -82,13 +107,16 @@ public:
     virtual ~AcqBoardONI();
 
     /** Detects whether a board is present */
-    bool detectBoard();
+    bool detectBoard() override;
 
     /** Initializes board after successful detection */
-    bool initializeBoard();
+    bool initializeBoard() override;
+
+    /** Initializes board in background thread */
+    bool initializeBoardInThread();
 
     /** Returns true if the device is connected */
-    bool foundInputSource() const;
+    bool foundInputSource() const override;
 
     /** Returns an array of connected headstages for this board */
     Array<const Headstage*> getHeadstages();


### PR DESCRIPTION
Added an InitializerThread to handle the initialization of the ONI Acquisition board in a background thread. This thread displays a "loading" window, providing visual feedback to the user during the initialization process. By running this step in the background, the main thread is not blocked, allowing UI updates to continue uninterrupted.