### PR TITLE
Address initial comments on updates to firmware

### DIFF
--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -750,7 +750,7 @@ void AcqBoardONI::scanPortsInThread()
               {
                 evalBoard->setBnoAxisMap (i, 0b00100100);
               }
-              else if (hasI2c[i])
+              else
               {
                   switch (headstageId[i])
                   {

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -115,12 +115,10 @@ bool AcqBoardONI::detectBoard()
         {
             LOGC ("FTDI Library version: ", major, ".", minor, ".", patch);
         }
-        if (evalBoard->getFirmwareVersion (&major, &minor))
+        if (evalBoard->getFirmwareVersion (&major, &minor, &patch))
         {
-            LOGC ("Open Ephys ECP5-ONI FPGA open. Gateware version v", major, ".", minor);
-            //if (major >= 16) //For now we use this, we will use the proper versioning
-            //    hasBNO[0] = true;
-            hasI2cSupport = major >= 2;
+            LOGC ("Open Ephys ECP5-ONI FPGA open. Gateware version v", major, ".", minor + "." + patch);
+            hasI2cSupport = major >= 1 && minor > 5;
         }
 
         deviceFound = true;

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -738,28 +738,31 @@ void AcqBoardONI::scanPortsInThread()
 
         for (int i = 0; i < numberOfPorts; i += 1)
         {
-            hasBNO[i] = evalBoard->isBnoConnected (Rhd2000ONIBoard::DEVICE_BNO_A + i * 2);
-            evalBoard->enableBnoStream (Rhd2000ONIBoard::DEVICE_BNO_A + i * 2, hasBNO[i]);
+            hasBNO[i] = evalBoard->isBnoConnected (i);
+            evalBoard->enableBnoStream (i, hasBNO[i]);
 
-            hasI2c[i] = evalBoard->isI2cCapable (Rhd2000ONIBoard::DEVICE_I2C_RAW_A + i * 2);
-            headstageId[i] = hasI2c[i] ? evalBoard->getDeviceIdOnEeprom (Rhd2000ONIBoard::DEVICE_I2C_RAW_A + i * 2) : 0;
+            hasI2c[i] = evalBoard->isI2cCapable (i);
+            headstageId[i] = hasI2c[i] ? evalBoard->getDeviceIdOnEeprom (i) : 0;
 
-            if (hasBNO[i] && !hasI2c[i]) // NB: 1st revision BNO capable LP headstage contains BNO but no EEPROM
+            if (hasBNO[i])
             {
-                evalBoard->setBnoAxisMap (Rhd2000ONIBoard::DEVICE_BNO_A + i * 2, 0b00100100);
-            }
-            else if (hasI2c[i])
-            {
-                switch (headstageId[i])
-                {
-                    // TODO: Add headstages here with the required axis map
-                    default:
-                        evalBoard->setBnoAxisMap (Rhd2000ONIBoard::DEVICE_BNO_A + i * 2, 0b00100100);
-                        break;
-                }
+              if (headstageId[i] == 0) // NB: 1st revision BNO capable LP headstage contains BNO but no EEPROM
+              {
+                evalBoard->setBnoAxisMap (i, 0b00100100);
+              }
+              else if (hasI2c[i])
+              {
+                  switch (headstageId[i])
+                  {
+                      // TODO: Add headstages here with the required axis map
+                      default:
+                          evalBoard->setBnoAxisMap (i, 0b00100100);
+                          break;
+                  }
+              }
             }
 
-            enableI2c[i] = hasBNO[i] || hasI2c[i];
+            enableI2c[i] = hasBNO[i] || (hasI2c[i] && headstageId[i] != 0);
         }
 
         evalBoard->enableI2cMode (enableI2c);

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1189,12 +1189,14 @@ bool Rhd2000ONIBoard::enableI2cMode (bool enablePort[4])
     return true;
 }
 
-bool Rhd2000ONIBoard::isI2cCapable(oni_dev_idx_t device)
+bool Rhd2000ONIBoard::isI2cCapable(const uint32_t port)
 {
-    if (! ctx || (device != DEVICE_I2C_RAW_A && device != DEVICE_I2C_RAW_B && device != DEVICE_I2C_RAW_C && device != DEVICE_I2C_RAW_D))
+    if (! ctx || port > 3)
         return false;
 
     oni_reg_val_t val;
+
+    oni_dev_idx_t device = DEVICE_I2C_RAW_A + port * 2;
 
     int result = oni_read_reg(ctx, device, (oni_reg_addr_t)I2cRawRegisters::I2C_BUS_READY, &val);
 
@@ -1204,43 +1206,80 @@ bool Rhd2000ONIBoard::isI2cCapable(oni_dev_idx_t device)
     return val > 0;
 }
 
-int Rhd2000ONIBoard::readByte(uint32_t address, oni_reg_addr_t i2cRawAddress, oni_reg_val_t* value, bool sixteenBitAddress)
+int Rhd2000ONIBoard::readByte (oni_dev_idx_t device, uint32_t address, oni_reg_val_t* value)
 {
-    uint32_t i2cAddress = 0x50; 
+    if (! ctx)
+        return 0;
 
-    uint32_t registerAddress = (address << 7) | (i2cAddress & 0x7F);
-    registerAddress |= sixteenBitAddress ? 0x80000000 : 0;
-
-    int result = oni_read_reg (ctx, i2cRawAddress, registerAddress, value);
+    int result = oni_read_reg (ctx, device, address, value);
 
     return result;
 }
 
-uint32_t Rhd2000ONIBoard::getDeviceIdOnEeprom (oni_reg_addr_t i2cRawAddress)
+int Rhd2000ONIBoard::readEepromByte (oni_dev_idx_t i2cRawAddress, uint32_t address, uint8_t& byte)
 {
-    if (i2cRawAddress != DEVICE_I2C_RAW_A && i2cRawAddress != DEVICE_I2C_RAW_B && i2cRawAddress != DEVICE_I2C_RAW_C && i2cRawAddress != DEVICE_I2C_RAW_D)
+    uint32_t i2cAddress = 0x50;
+
+    uint32_t registerAddress = (address << 7) | (i2cAddress & 0x7F);
+    registerAddress |= 0x80000000;
+
+    oni_reg_val_t value;
+
+    int result = readByte (i2cRawAddress, registerAddress, &value);
+
+    if (result == 0)
+        byte = (uint8_t) (value & 0xFF);
+    else
+        byte = 0;
+
+    return result;
+}
+
+uint32_t Rhd2000ONIBoard::getDeviceIdOnEeprom (const uint32_t port)
+{
+    if (!ctx || port > 3)
         return 0;
+
+    oni_dev_idx_t i2cRawAddress = DEVICE_I2C_RAW_A + port * 2;
+
+    // NB: Confirm EEPROM first four bytes contains OESH
+    const char identifier[] = "OESH";
+
+    for (unsigned int i = 0; i < strlen(identifier); i += 1)
+    {
+        uint8_t val;
+        int res;
+        res = readEepromByte (i2cRawAddress, i, val);
+
+        if (res != 0 || val != identifier[i])
+            return 0;
+    }
 
     const uint32_t deviceIdStartAddress = 7;
     uint32_t data = 0;
 
     for (unsigned int i = 0; i < sizeof (uint32_t); i++)
     {
-        oni_reg_val_t val;
+        uint8_t val;
         int res;
-        res = readByte (deviceIdStartAddress + i, i2cRawAddress, &val, true);
-        data += (val & 0xFF) << (8 * i);
+        res = readEepromByte (i2cRawAddress, deviceIdStartAddress + i, val);
+
+        if (res != 0)
+            return 0;
+
+        data += val << (8 * i);
     }
 
     return data;
 }
 
-bool Rhd2000ONIBoard::isBnoConnected (oni_dev_idx_t device)
+bool Rhd2000ONIBoard::isBnoConnected (const uint32_t port)
 {
-    if (! ctx || (device != DEVICE_BNO_A && device != DEVICE_BNO_B && device != DEVICE_BNO_C && device != DEVICE_BNO_D))
+    if (! ctx || port > 3)
         return false;
 
     oni_reg_val_t val = 2; // Value == 2 means there is a BNO scan in progress
+    oni_dev_idx_t device = DEVICE_I2C_RAW_A + port * 2;
     int result;
 
     while (val == 2)
@@ -1254,29 +1293,36 @@ bool Rhd2000ONIBoard::isBnoConnected (oni_dev_idx_t device)
     return val == 1;
 }
 
-void Rhd2000ONIBoard::enableBnoStream(oni_dev_idx_t bnoIndex, bool enabled)
+void Rhd2000ONIBoard::enableBnoStream(const uint32_t port, bool enabled)
 {
-    if (bnoIndex != DEVICE_BNO_A && bnoIndex != DEVICE_BNO_B && bnoIndex != DEVICE_BNO_C && bnoIndex != DEVICE_BNO_D)
+    if (! ctx || port > 3)
         return;
 
-    oni_write_reg (ctx, bnoIndex, 0, static_cast<int> (enabled));
+    oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
+
+    oni_write_reg (ctx, device, 0, static_cast<int> (enabled));
 }
 
-bool Rhd2000ONIBoard::isBnoEnabled (oni_dev_idx_t bnoIndex)
+bool Rhd2000ONIBoard::isBnoEnabled (const uint32_t port)
 {
-    if (bnoIndex != DEVICE_BNO_A && bnoIndex != DEVICE_BNO_B && bnoIndex != DEVICE_BNO_C && bnoIndex != DEVICE_BNO_D)
+    if (! ctx || port > 3)
         return false;
 
+    oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
     oni_reg_val_t val;
-    if (oni_read_reg (ctx, bnoIndex, 0, &val) != ONI_ESUCCESS)
+    
+    if (oni_read_reg (ctx, device, 0, &val) != ONI_ESUCCESS)
         return false;
+    
     return static_cast<bool>(val);
 }
 
-void Rhd2000ONIBoard::setBnoAxisMap(oni_dev_idx_t device, int axisMap)
+void Rhd2000ONIBoard::setBnoAxisMap (const uint32_t port, int axisMap)
 {
-    if (! ctx || (device != DEVICE_BNO_A && device != DEVICE_BNO_B && device != DEVICE_BNO_C && device != DEVICE_BNO_D))
+    if (! ctx || port > 3)
         return;
+
+    oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
 
     oni_write_reg (ctx, device, (uint32_t)BnoRegisters::AXIS_MAP, axisMap);
 }

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1148,15 +1148,16 @@ void Rhd2000ONIBoard::setDacManual (int value)
         std::cerr << "Error creating frame for DAC writing " << res << ": " << oni_error_str (res) << std::endl;
 }
 
-bool Rhd2000ONIBoard::getFirmwareVersion (int* major, int* minor) const
+bool Rhd2000ONIBoard::getFirmwareVersion (int* major, int* minor, int* patch) const
 {
     if (! ctx)
         return false;
     oni_reg_val_t val;
     if (oni_read_reg (ctx, 254, 2, &val) != ONI_ESUCCESS)
         return false;
-    *minor = val & 0xFF;
-    *major = (val >> 8) & 0xFF;
+    *patch = val & 0xFF;
+    *minor = (val >> 8) & 0xFF;
+    *major = (val >> 16) & 0xFF;
     return true;
 }
 

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -153,14 +153,13 @@ public:
     bool getFTLibInfo (int* major, int* minor, int* patch);
 
     bool enableI2cMode (bool[4]);
-    bool isI2cCapable (const oni_dev_idx_t);
-    bool isBnoConnected (const oni_dev_idx_t);
-    void enableBnoStream (oni_dev_idx_t bnoIndex, bool enabled);
-    bool isBnoEnabled (oni_dev_idx_t bnoIndex);
-    void setBnoAxisMap (oni_dev_idx_t, int);
+    bool isI2cCapable (const uint32_t);
+    bool isBnoConnected (const uint32_t);
+    void enableBnoStream (const uint32_t, bool);
+    bool isBnoEnabled (const uint32_t);
+    void setBnoAxisMap (const uint32_t, int);
 
-    int readByte (uint32_t, oni_reg_addr_t, oni_reg_val_t*, bool);
-    uint32_t getDeviceIdOnEeprom (oni_reg_addr_t);
+    uint32_t getDeviceIdOnEeprom (const uint32_t);
 
     enum BoardMemState
     {
@@ -192,6 +191,9 @@ private:
     const oni_size_t usbReadBlockSize = 24 * 1024;
 
     static int oni_write_reg_mask (const oni_ctx ctx, oni_dev_idx_t dev_idx, oni_reg_addr_t addr, oni_reg_val_t value, unsigned int mask);
+
+    int readByte (oni_dev_idx_t, uint32_t, oni_reg_val_t*);
+    int readEepromByte (oni_dev_idx_t, uint32_t, uint8_t&);
 
     enum Rhythm_Registers
     {

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -145,7 +145,7 @@ public:
     void setDacManual (int value);
     void setDacGain (int gain);
 
-    bool getFirmwareVersion (int* major, int* minor) const;
+    bool getFirmwareVersion (int* major, int* minor, int* patch) const;
 
     void getONIVersion (int* major, int* minor, int* patch);
     void getONIDriverInfo (const oni_driver_info_t** driverInfo);

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -192,7 +192,7 @@ private:
 
     static int oni_write_reg_mask (const oni_ctx ctx, oni_dev_idx_t dev_idx, oni_reg_addr_t addr, oni_reg_val_t value, unsigned int mask);
 
-    int readByte (oni_dev_idx_t, uint32_t, oni_reg_val_t*);
+    int readByte (oni_dev_idx_t, uint32_t, oni_reg_addr_t, oni_reg_val_t*, bool);
     int readEepromByte (oni_dev_idx_t, uint32_t, uint8_t&);
 
     enum Rhythm_Registers


### PR DESCRIPTION
- Find device address for methods based on the given port number
- Reorder parameters to be consistent with oni_* calls
- Before reading device IDs from an EEPROM, confirm that the first four bytes contain the characters "OESH"
- Make readBytes() more flexible, and create readEepromBytes() specifically for EEPROM byte reads
- Corrected logic for devices with a BNO but no EEPROM

Fixes #18 