### PR TITLE
Refactor AcqBoardOutput to correctly register parameters and fix crashes

### DIFF
--- a/Source/AcqBoardOutput.h
+++ b/Source/AcqBoardOutput.h
@@ -43,6 +43,9 @@ public:
     /** Destructor*/
     ~AcqBoardOutput() {}
 
+    /** Registers the parameters*/
+    void registerParameters() override;
+
     /** Searches for events and triggers the Arduino output when appropriate. */
     void process (AudioBuffer<float>& buffer) override;
 
@@ -53,7 +56,7 @@ public:
     AudioProcessorEditor* createEditor() override;
 
     /** Manually triggers output when editor button is clicked */
-    void triggerOutput (uint16 streamId);
+    void triggerOutput ();
 
     /** Responds to change in parameter trigger value */
     void parameterValueChanged (Parameter*) override;

--- a/Source/AcqBoardOutputEditor.cpp
+++ b/Source/AcqBoardOutputEditor.cpp
@@ -29,17 +29,24 @@ AcqBoardOutputEditor::AcqBoardOutputEditor (GenericProcessor* parentNode)
     : GenericEditor (parentNode)
 
 {
-    desiredWidth = 250;
+    desiredWidth = 190;
 
     board = (AcqBoardOutput*) parentNode;
 
-    addComboBoxParameterEditor (Parameter::STREAM_SCOPE, "ttl_out", 10, 30);
-    addComboBoxParameterEditor (Parameter::STREAM_SCOPE, "trigger_line", 10, 76);
-    addComboBoxParameterEditor (Parameter::STREAM_SCOPE, "gate_line", 100, 76);
-    addTextBoxParameterEditor (Parameter::GLOBAL_SCOPE, "event_duration", 100, 30);
+    addTtlLineParameterEditor (Parameter::STREAM_SCOPE, "ttl_out", 10, 25);
+    addTtlLineParameterEditor (Parameter::STREAM_SCOPE, "trigger_line", 10, 65);
+    addTtlLineParameterEditor (Parameter::STREAM_SCOPE, "gate_line", 100, 65);
+    addBoundedValueParameterEditor (Parameter::PROCESSOR_SCOPE, "event_duration", 100, 25);
+
+    for (auto ed : parameterEditors)
+    {
+        ed->setLayout (ParameterEditor::Layout::nameOnTop);
+        ed->setSize (80, 36);
+    }
 
     triggerButton = std::make_unique<UtilityButton> ("Trigger");
-    triggerButton->setBounds (190, 95, 55, 25);
+    triggerButton->setBounds (55, 105, 80, 20);
+    triggerButton->setFont (FontOptions(12.0f));
     triggerButton->addListener (this);
     addAndMakeVisible (triggerButton.get());
 }
@@ -49,6 +56,6 @@ void AcqBoardOutputEditor::buttonClicked (Button* button)
     if (button == triggerButton.get())
     {
         AcqBoardOutput* processor = (AcqBoardOutput*) getProcessor();
-        processor->triggerOutput (getCurrentStream());
+        processor->triggerOutput ();
     }
 }

--- a/Source/DeviceThread.cpp
+++ b/Source/DeviceThread.cpp
@@ -249,8 +249,6 @@ void DeviceThread::handleBroadcastMessage (const String& msg, const int64 messag
 {
     StringArray parts = StringArray::fromTokens (msg, " ", "");
 
-    //std::cout << "Received " << msg << std::endl;
-
     if (parts[0].equalsIgnoreCase ("ACQBOARD"))
     {
         if (parts.size() > 1)

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -27,7 +27,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include "AcqBoardOutput.h"
 
 #include <string>
-#ifdef WIN32
+#ifdef _WIN32
 #include <Windows.h>
 #define EXPORT __declspec(dllexport)
 #else
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "0.1.1";
+	info->libVersion = "0.1.2";
 	info->numPlugins = NUM_PLUGINS;
 }
 


### PR DESCRIPTION
- Use `registerParameters()` to create and register parameters
- Replace `GLOBAL` scope with `PROCESSOR` scope for `trigger` and `event_duration` parameters
- Use `TtlLineParameter` and `TtlLineParameterEditor` for `ttl_out`, `trigger_line`, and `gate_line` parameters
- Update editor layout


![Acq Board Output_105](https://github.com/user-attachments/assets/7f000a72-80b8-474c-b39b-d74bae4b1ebe)
