### PR TITLE
Add BNO functionality

### DIFF
--- a/Source/DeviceEditor.cpp
+++ b/Source/DeviceEditor.cpp
@@ -823,7 +823,8 @@ void HeadstageOptionsInterface::checkEnabledState()
     if (board->isHeadstageEnabled (hsNumber1))
     {
         channelsOnHs1 = board->getActiveChannelsInHeadstage (hsNumber1);
-        hsButton1->setLabel (String (channelsOnHs1));
+        String label = channelsOnHs1 == 0 ? "IMU" : String (channelsOnHs1); // NB: No active channels indicates a BNO is connected instead
+        hsButton1->setLabel (label);
         hsButton1->setEnabledState (true);
         hsButton1->setToggleState (true, false);
     }
@@ -840,7 +841,8 @@ void HeadstageOptionsInterface::checkEnabledState()
     if (board->isHeadstageEnabled (hsNumber2))
     {
         channelsOnHs2 = board->getActiveChannelsInHeadstage (hsNumber2);
-        hsButton2->setLabel (String (channelsOnHs2));
+        String label = channelsOnHs1 == 0 ? "IMU" : String (channelsOnHs1); // NB: No active channels indicates a BNO is connected instead
+        hsButton1->setLabel (label);
         hsButton2->setEnabledState (true);
         hsButton2->setToggleState (true, false);
     }

--- a/Source/DeviceThread.cpp
+++ b/Source/DeviceThread.cpp
@@ -128,6 +128,11 @@ bool DeviceThread::foundInputSource()
     return deviceFound;
 }
 
+bool DeviceThread::isReady()
+{
+    return acquisitionBoard->isReady();
+}
+
 bool DeviceThread::startAcquisition()
 {
     return acquisitionBoard->startAcquisition();

--- a/Source/DeviceThread.h
+++ b/Source/DeviceThread.h
@@ -67,6 +67,8 @@ public:
     /** Informs Source Node whether a device is available */
     bool foundInputSource() override;
 
+    bool isReady() override;
+
     /** Initializes data transfer*/
     bool startAcquisition() override;
 

--- a/Source/UI/ChannelList.cpp
+++ b/Source/UI/ChannelList.cpp
@@ -133,6 +133,9 @@ void ChannelList::update()
 
     for (auto hs : headstages)
     {
+        if (hs->getNumActiveChannels() == 0)
+            continue;
+
         column++;
 
         maxChannels = hs->getNumActiveChannels() > maxChannels ? hs->getNumActiveChannels() : maxChannels;

--- a/Source/devices/AcquisitionBoard.h
+++ b/Source/devices/AcquisitionBoard.h
@@ -110,6 +110,8 @@ public:
     /** Gets the method for determining channel names*/
     virtual ChannelNamingScheme getNamingScheme() = 0;
 
+    virtual bool isReady() = 0;
+
     /** Initiates data transfer */
     virtual bool startAcquisition() = 0;
 

--- a/Source/devices/AcquisitionBoard.h
+++ b/Source/devices/AcquisitionBoard.h
@@ -25,9 +25,9 @@
 
 #include <DataThreadHeaders.h>
 
+#include "../DeviceEditor.h"
 #include "Headstage.h"
 #include "ImpedanceMeter.h"
-#include "../DeviceEditor.h"
 
 /** Instructions for settings digital output */
 struct DigitalOutputCommand
@@ -48,9 +48,9 @@ class AcquisitionBoard : public Thread
 {
 public:
     /** Constructor */
-    AcquisitionBoard (DataBuffer* buffer_) : Thread ("Acquisition Board"),
-                                             buffer (buffer_)
+    AcquisitionBoard () : Thread ("Acquisition Board")
     {
+        buffer = nullptr;
     }
 
     /** Destructor */
@@ -128,7 +128,7 @@ public:
     virtual double setDspCutoffFreq (double freq) = 0;
 
     /** Gets the current DSP cutoff frequency */
-    virtual double getDspCutoffFreq () const = 0;
+    virtual double getDspCutoffFreq() const = 0;
 
     /** Sets whether DSP offset is enabled */
     virtual void setDspOffset (bool enabled) = 0;
@@ -202,8 +202,14 @@ public:
     /** Create stream and channel structures is the acquisition board type has custom streams and updates the buffers */
     virtual void updateCustomStreams (OwnedArray<DataStream>& otherStreams, OwnedArray<ContinuousChannel>& otherChannels) {};
 
+    DataBuffer* getBuffer()
+    {
+        buffer = new DataBuffer (getNumChannels(), 10000);
+        return buffer;
+    }
+
 protected:
-    /** Timer for triggering digtial outputs */
+    /** Timer for triggering digital outputs */
     class DigitalOutputTimer : public Timer
     {
     public:
@@ -220,7 +226,6 @@ protected:
         /** Sends signal to turn off event channel*/
         void timerCallback()
         {
-        
             stopTimer();
 
             board->addDigitalOutputCommand (this, tllOutputLine, false);
@@ -242,8 +247,6 @@ protected:
 
         digitalOutputTimers.removeObject (timerToDelete);
     }
-
-
 
     /** Sample buffer to fill */
     DataBuffer* buffer;
@@ -337,7 +340,6 @@ protected:
 
     /** True if change in settings is needed during acquisition*/
     bool updateSettingsDuringAcquisition = false;
-
 };
 
 #endif

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -272,6 +272,8 @@ bool AcqBoardONI::initializeBoard()
     evalBoard->selectAuxCommandBank (Rhd2000ONIBoard::PortC, Rhd2000ONIBoard::AuxCmd3, settings.fastSettleEnabled ? 2 : 1);
     evalBoard->selectAuxCommandBank (Rhd2000ONIBoard::PortD, Rhd2000ONIBoard::AuxCmd3, settings.fastSettleEnabled ? 2 : 1);
 
+    evalBoard->getAcquisitionClockHz (&acquisitionClockHz);
+
     return true;
 }
 
@@ -683,6 +685,9 @@ int AcqBoardONI::getIntanChipId (
     int& register59Value)
 {
     bool intanChipPresent;
+
+    if (stream < 0)
+        return 0;
 
     // First, check ROM registers 32-36 to verify that they hold 'INTAN', and
     // the initial chip name ROM registers 24-26 that hold 'RHD'.
@@ -1571,7 +1576,7 @@ void AcqBoardONI::run()
                 float memf = membytes * 0.1f;
                 uint64 zero = 0;
                 int64 tst = frame->time;
-                double tsd = frame->time / 50e6;
+                double tsd = static_cast<double>(frame->time) / acquisitionClockHz;
                 memBuffer->addToBuffer (
                     &memf,
                     &tst,
@@ -1661,7 +1666,7 @@ void AcqBoardONI::addBnoDataToBuffer (oni_frame_t* frame, DataBuffer* buffer)
     unsigned char* bufferPtr = (unsigned char*) frame->data + 8 + 6;
     uint64 zero = 0;
     int64 tst = frame->time;
-    double tsd = frame->time / 50e6;
+    double tsd = static_cast<double> (frame->time) / acquisitionClockHz;
     float quatdata[4];
     for (int i = 0; i < 4; i++)
     {

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -53,7 +53,7 @@ AcqBoardONI::AcqBoardONI (DataBuffer* buffer_) : AcquisitionBoard (buffer_),
         dacThresholds.set (k, 0);
     }
 
-    for (int i = 0; i < numberOfPorts; i++)
+    for (int i = 0; i < NUMBER_OF_PORTS; i++)
     {
         hasBNO[i] = false;
         bnoBuffers.add (nullptr);
@@ -134,7 +134,7 @@ void AcqBoardONI::createCustomStreams (OwnedArray<DataBuffer>& otherBuffers)
 {
     memBuffer = otherBuffers.add (new DataBuffer (1, 10000)); // Memory device
 
-    for (int i = 0; i < numberOfPorts; i++)
+    for (int i = 0; i < NUMBER_OF_PORTS; i++)
     {
         if (hasBNO[i])
             bnoBuffers.set (i, otherBuffers.add (new DataBuffer (4, 10000)));
@@ -173,7 +173,7 @@ void AcqBoardONI::updateCustomStreams (OwnedArray<DataStream>& otherStreams, Own
     String port = "ABCD";
 
     //BNO
-    for (int k = 0; k < numberOfPorts; k++)
+    for (int k = 0; k < NUMBER_OF_PORTS; k++)
     {
         if (hasBNO[k])
         {
@@ -734,7 +734,7 @@ void AcqBoardONI::scanPortsInThread()
         evalBoard->enableI2cMode (enableI2c);
         evalBoard->resetBoard();
 
-        for (int i = 0; i < numberOfPorts; i += 1)
+        for (int i = 0; i < NUMBER_OF_PORTS; i += 1)
         {
             hasBNO[i] = evalBoard->isBnoConnected (i);
             evalBoard->enableBnoStream (i, hasBNO[i]);
@@ -954,6 +954,10 @@ void AcqBoardONI::scanPortsInThread()
                 enableHeadstage (hs, true, 1, tmpChipId[hs] == 1 ? 32 : 16);
             }
         }
+        else if (hs % 2 == 0 && hasBNO[hs / 2])
+        {
+            enableHeadstage (hs, true, 0, 0, true);
+        }
         else
         {
             enableHeadstage (hs, false);
@@ -1026,7 +1030,7 @@ void AcqBoardONI::setCableLength (int hsNum, float length)
     }
 }
 
-bool AcqBoardONI::enableHeadstage (int hsNum, bool enabled, int nStr, int strChans)
+bool AcqBoardONI::enableHeadstage (int hsNum, bool enabled, int nStr, int strChans, bool hasBNO)
 {
     LOGD ("Headstage ", hsNum, ", enabled: ", enabled, ", num streams: ", nStr, ", stream channels: ", strChans);
     LOGD ("Max num headstages: ", MAX_NUM_HEADSTAGES);
@@ -1035,6 +1039,7 @@ bool AcqBoardONI::enableHeadstage (int hsNum, bool enabled, int nStr, int strCha
     {
         headstages[hsNum]->setFirstChannel (getNumDataOutputs (ContinuousChannel::ELECTRODE));
         headstages[hsNum]->setNumStreams (nStr);
+        headstages[hsNum]->setHasBno (hasBNO);
         headstages[hsNum]->setChannelsPerStream (strChans);
         headstages[hsNum]->setFirstStreamIndex (enabledStreams.size());
         enabledStreams.add (headstages[hsNum]->getDataStream (0));

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -117,8 +117,8 @@ bool AcqBoardONI::detectBoard()
         }
         if (evalBoard->getFirmwareVersion (&major, &minor, &patch))
         {
-            LOGC ("Open Ephys ECP5-ONI FPGA open. Gateware version v", major, ".", minor + "." + patch);
-            hasI2cSupport = major >= 1 && minor > 5;
+            LOGC ("Open Ephys ECP5-ONI FPGA open. Gateware version v", major, ".", minor, ".", patch);
+            hasI2cSupport = major >= 1 && minor >= 5;
         }
 
         deviceFound = true;

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -1362,14 +1362,17 @@ void AcqBoardONI::connectHeadstageChannelToDAC (int headstageChannelIndex, int d
     }
 }
 
-bool AcqBoardONI::startAcquisition()
+bool AcqBoardONI::isReady()
 {
     if (! deviceFound || (getNumChannels() == 0))
         return false;
 
     if (! checkBoardMem())
         return false;
+}
 
+bool AcqBoardONI::startAcquisition()
+{
     impedanceMeter->waitSafely();
     dataBlock.reset (new Rhd2000ONIDataBlock (evalBoard->getNumEnabledDataStreams(), evalBoard->isUSB3()));
 

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -76,7 +76,7 @@ class AcqBoardONI : public AcquisitionBoard
 
 public:
     /** Constructor */
-    AcqBoardONI (DataBuffer* buffer_);
+    AcqBoardONI();
 
     /** Destructor */
     virtual ~AcqBoardONI();
@@ -196,6 +196,9 @@ public:
 
     /** Returns the total number of channels in a headstage */
     int getChannelsInHeadstage (int hsNum) const;
+
+    /** Returns the number of BNO devices attached */
+    int getNumBnos() const;
 
     /** Returns total number of outputs per channel type */
     int getNumDataOutputs (ContinuousChannel::Type);

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -306,6 +306,8 @@ private:
     uint32_t headstageId[NUMBER_OF_PORTS];
     bool hasI2cSupport = false;
 
+    uint32_t acquisitionClockHz;
+
     DataBuffer* memBuffer;
     Array<DataBuffer*, juce::DummyCriticalSection, NUMBER_OF_PORTS> bnoBuffers;
 };

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -141,6 +141,8 @@ public:
     /** Gets the method for determining channel names*/
     ChannelNamingScheme getNamingScheme();
 
+    bool isReady() override;
+
     /** Initializes data transfer*/
     bool startAcquisition();
 

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -296,6 +296,7 @@ private:
 
     static constexpr int NUMBER_OF_PORTS = 4;
     static constexpr int BNO_CHANNELS = 4;
+    static constexpr int MEMORY_MONITOR_FS = 100;
 
     int regOffset;
     bool varSampleRateCapable = false;
@@ -307,6 +308,7 @@ private:
     bool hasI2cSupport = false;
 
     uint32_t acquisitionClockHz;
+    uint32_t totalMemory;
 
     DataBuffer* memBuffer;
     Array<DataBuffer*, juce::DummyCriticalSection, NUMBER_OF_PORTS> bnoBuffers;

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -227,7 +227,7 @@ private:
     void setCableLength (int hsNum, float length);
 
     /** Enables or disables a given headstage */
-    bool enableHeadstage (int hsNum, bool enabled, int nStr = 1, int strChans = 32);
+    bool enableHeadstage (int hsNum, bool enabled, int nStr = 1, int strChans = 32, bool hasBno = false);
 
     /**Returns the global channel index for a local headstage channel */
     int getChannelFromHeadstage (int headstageIndex, int channelIndex);
@@ -292,19 +292,20 @@ private:
     /** Re-check cable delays after changing sample rate*/
     bool checkCableDelays = false;
 
-    static const int numberOfPorts = 4;
+    static constexpr int NUMBER_OF_PORTS = 4;
+    static constexpr int BNO_CHANNELS = 4;
 
     int regOffset;
     bool varSampleRateCapable = false;
     bool commonCommandsSet = false;
     bool initialScan = true;
-    bool hasBNO[numberOfPorts]; // Tracks if there is a BNO on any of the available ports
-    bool hasI2c[numberOfPorts]; // Tracks if there is an I2C-capable device on any of the available ports
-    uint32_t headstageId[numberOfPorts];
+    bool hasBNO[NUMBER_OF_PORTS]; // Tracks if there is a BNO on any of the available ports
+    bool hasI2c[NUMBER_OF_PORTS]; // Tracks if there is an I2C-capable device on any of the available ports
+    uint32_t headstageId[NUMBER_OF_PORTS];
     bool hasI2cSupport = false;
 
     DataBuffer* memBuffer;
-    Array<DataBuffer*, juce::DummyCriticalSection, numberOfPorts> bnoBuffers;
+    Array<DataBuffer*, juce::DummyCriticalSection, NUMBER_OF_PORTS> bnoBuffers;
 };
 
 #endif

--- a/Source/devices/oni/HeadstageONI.cpp
+++ b/Source/devices/oni/HeadstageONI.cpp
@@ -30,7 +30,8 @@ HeadstageONI::HeadstageONI (Rhd2000ONIBoard::BoardDataSource dataSource_,
                                          numStreams (0),
                                          channelsPerStream (32),
                                          halfChannels (false),
-                                         streamIndex (-1)
+                                         streamIndex (-1),
+                                         m_hasBno (false)
 {
 }
 
@@ -52,6 +53,11 @@ void HeadstageONI::setNumStreams (int num)
 
         generateChannelNames (channelNamingScheme);
     }
+}
+
+void HeadstageONI::setHasBno (bool hasBno)
+{
+    m_hasBno = hasBno;
 }
 
 void HeadstageONI::setChannelsPerStream (int nchan)
@@ -108,7 +114,7 @@ Rhd2000ONIBoard::BoardDataSource HeadstageONI::getDataStream (int index) const
 
 bool HeadstageONI::isConnected() const
 {
-    return (numStreams > 0);
+    return numStreams > 0 || m_hasBno;
 }
 
 String HeadstageONI::getChannelName (int ch) const

--- a/Source/devices/oni/HeadstageONI.h
+++ b/Source/devices/oni/HeadstageONI.h
@@ -27,8 +27,8 @@
 #include "../ImpedanceMeter.h"
 
 #include "rhythm-api/okFrontPanelDLL.h"
-#include "rhythm-api/rhd2000ONIdatablock.h"
 #include "rhythm-api/rhd2000ONIboard.h"
+#include "rhythm-api/rhd2000ONIdatablock.h"
 #include "rhythm-api/rhd2000ONIregisters.h"
 
 /** 
@@ -82,6 +82,9 @@ public:
     /** Sets the number of streams for this headstage (1 or 2)*/
     void setNumStreams (int num);
 
+    /** Sets whether or not there is a BNO on this headstage */
+    void setHasBno (bool hasBno);
+
     /** Returns true if the headstage is connected*/
     bool isConnected() const;
 
@@ -106,6 +109,8 @@ private:
     int channelsPerStream;
 
     bool halfChannels;
+
+    bool m_hasBno;
 
     int MAX_NUM_HEADSTAGES;
 

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1315,7 +1315,7 @@ bool Rhd2000ONIBoard::isBnoConnected (const uint32_t port)
     oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
     int result;
 
-    while (val == 2)
+    while (val >= 2)
     {
         result = oni_read_reg (ctx, device, (oni_reg_addr_t) BnoRegisters::BNO_STATUS, &val);
 
@@ -1333,7 +1333,7 @@ void Rhd2000ONIBoard::enableBnoStream (const uint32_t port, bool enabled)
 
     oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
 
-    oni_write_reg (ctx, device, 0, static_cast<int> (enabled));
+    int rc = oni_write_reg (ctx, device, (oni_reg_addr_t)BnoRegisters::ENABLE_BNO, static_cast<int> (enabled));
 }
 
 bool Rhd2000ONIBoard::isBnoEnabled (const uint32_t port)
@@ -1344,7 +1344,7 @@ bool Rhd2000ONIBoard::isBnoEnabled (const uint32_t port)
     oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
     oni_reg_val_t val;
     
-    if (oni_read_reg (ctx, device, 0, &val) != ONI_ESUCCESS)
+    if (oni_read_reg (ctx, device, (oni_reg_addr_t) BnoRegisters::ENABLE_BNO, &val) != ONI_ESUCCESS)
         return false;
     
     return static_cast<bool> (val);

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -91,12 +91,12 @@ bool Rhd2000ONIBoard::getFTLibInfo (int* major, int* minor, int* patch)
         return false;
 }
 
-bool Rhd2000ONIBoard::getAcquisitionClockHz(uint32_t* acqClkHz) const
+bool Rhd2000ONIBoard::getAcquisitionClockHz (uint32_t* acqClkHz) const
 {
     uint32_t val;
     size_t size = sizeof (val);
 
-    if (oni_get_opt(ctx, ONI_OPT_ACQCLKHZ, &val, &size) == ONI_ESUCCESS)
+    if (oni_get_opt (ctx, ONI_OPT_ACQCLKHZ, &val, &size) == ONI_ESUCCESS)
     {
         *acqClkHz = val;
         return true;
@@ -383,6 +383,25 @@ double Rhd2000ONIBoard::getSampleRate() const
         default:
             return -1.0;
     }
+}
+
+bool Rhd2000ONIBoard::setMemoryMonitorSampleRate (int sampleRate)
+{
+    oni_reg_val_t clkHz;
+    int rc = oni_read_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::CLK_HZ, &clkHz);
+    if (rc != ONI_ESUCCESS)
+        return false;
+
+    rc = oni_write_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::CLK_DIV, clkHz / sampleRate);
+
+    return rc == ONI_ESUCCESS;
+}
+
+bool Rhd2000ONIBoard::getTotalMemory(uint32_t* memory)
+{
+    int rc = oni_read_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::TOTAL_MEM, memory);
+
+    return rc == ONI_ESUCCESS;
 }
 
 // Print a command list to the console in readable form.
@@ -1204,13 +1223,12 @@ bool Rhd2000ONIBoard::enableI2cMode (bool enablePort[4])
     return true;
 }
 
-bool Rhd2000ONIBoard::isI2cCapable(const uint32_t port)
+bool Rhd2000ONIBoard::isI2cCapable (const uint32_t port)
 {
     if (! ctx || port > 3)
         return false;
 
     oni_reg_val_t val;
-
     oni_dev_idx_t device = DEVICE_I2C_RAW_A + port * 2;
 
     int result = oni_read_reg(ctx, device, (oni_reg_addr_t)I2cRawRegisters::I2C_BUS_READY, &val);
@@ -1224,7 +1242,7 @@ bool Rhd2000ONIBoard::isI2cCapable(const uint32_t port)
 int Rhd2000ONIBoard::readByte (oni_dev_idx_t device, uint32_t i2cDevAddress, oni_reg_addr_t i2cRegAddress, oni_reg_val_t* value, bool sixteenBitAddress)
 {
     if (! ctx)
-        return 0;
+        return 1;
 
     uint32_t registerAddress = (i2cRegAddress << 7) | (i2cDevAddress & 0x7F);
     registerAddress |= sixteenBitAddress ? 0x80000000 : 0;
@@ -1299,7 +1317,7 @@ bool Rhd2000ONIBoard::isBnoConnected (const uint32_t port)
 
     while (val == 2)
     {
-        result = oni_read_reg (ctx, device, (oni_reg_addr_t)BnoRegisters::BNO_STATUS, &val);
+        result = oni_read_reg (ctx, device, (oni_reg_addr_t) BnoRegisters::BNO_STATUS, &val);
 
         if (result != ONI_ESUCCESS)
             return false;
@@ -1308,7 +1326,7 @@ bool Rhd2000ONIBoard::isBnoConnected (const uint32_t port)
     return val == 1;
 }
 
-void Rhd2000ONIBoard::enableBnoStream(const uint32_t port, bool enabled)
+void Rhd2000ONIBoard::enableBnoStream (const uint32_t port, bool enabled)
 {
     if (! ctx || port > 3)
         return;
@@ -1329,15 +1347,15 @@ bool Rhd2000ONIBoard::isBnoEnabled (const uint32_t port)
     if (oni_read_reg (ctx, device, 0, &val) != ONI_ESUCCESS)
         return false;
     
-    return static_cast<bool>(val);
+    return static_cast<bool> (val);
 }
 
-void Rhd2000ONIBoard::setBnoAxisMap (const uint32_t port, int axisMap)
+void Rhd2000ONIBoard::setBnoAxisMap  (const uint32_t port, int axisMap)
 {
     if (! ctx || port > 3)
         return;
 
     oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
 
-    oni_write_reg (ctx, device, (uint32_t)BnoRegisters::AXIS_MAP, axisMap);
+    oni_write_reg (ctx, device, (uint32_t) BnoRegisters::AXIS_MAP, axisMap);
 }

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1311,11 +1311,14 @@ bool Rhd2000ONIBoard::isBnoConnected (const uint32_t port)
     if (! ctx || port > 3)
         return false;
 
-    oni_reg_val_t val = 2; // Value == 2 means there is a BNO scan in progress
+    oni_reg_val_t val = 2; // Value >= 2 means there is a BNO scan in progress
     oni_dev_idx_t device = DEVICE_BNO_A + port * 2;
     int result;
 
-    while (val >= 2)
+    using namespace std::chrono;
+    auto startTime = high_resolution_clock::now();
+
+    while (val >= 2 && duration_cast<seconds>(duration<double>(startTime - high_resolution_clock::now())) < 1s)
     {
         result = oni_read_reg (ctx, device, (oni_reg_addr_t) BnoRegisters::BNO_STATUS, &val);
 

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -91,6 +91,20 @@ bool Rhd2000ONIBoard::getFTLibInfo (int* major, int* minor, int* patch)
         return false;
 }
 
+bool Rhd2000ONIBoard::getAcquisitionClockHz(uint32_t* acqClkHz) const
+{
+    uint32_t val;
+    size_t size = sizeof (val);
+
+    if (oni_get_opt(ctx, ONI_OPT_ACQCLKHZ, &val, &size) == ONI_ESUCCESS)
+    {
+        *acqClkHz = val;
+        return true;
+    }
+
+    return false;
+}
+
 void Rhd2000ONIBoard::initialize()
 {
     int i;

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -4,6 +4,9 @@
 #include <oni.h>
 #include <queue>
 #include <vector>
+#include <chrono>
+
+using namespace std::chrono_literals;
 
 #define MAX_NUM_DATA_STREAMS_USB3 16
 

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -78,8 +78,8 @@ public:
 
     enum class I2cRawRegisters : oni_reg_addr_t
     {
-        ENABLE = 0x0,
-        I2C_BUS_READY = 0x1
+        ENABLE = 0x0 + (1 << 15),
+        I2C_BUS_READY = 0x1 + (1 << 15)
     };
 
     enum class MemoryMonitorRegisters : uint32_t

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -82,6 +82,14 @@ public:
         I2C_BUS_READY = 0x1
     };
 
+    enum class MemoryMonitorRegisters : uint32_t
+    {
+        ENABLE = 0,
+        CLK_DIV = 1,
+        CLK_HZ = 2,
+        TOTAL_MEM = 3
+    };
+
     bool isUSB3();
     int open (const oni_driver_info_t** driverInfo = nullptr);
     void initialize();
@@ -114,6 +122,9 @@ public:
 
     bool setSampleRate (AmplifierSampleRate newSampleRate);
     double getSampleRate() const;
+
+    bool setMemoryMonitorSampleRate (int sampleRate);
+    bool getTotalMemory (uint32_t*);
 
     void setDspSettle (bool enabled);
 

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -152,6 +152,8 @@ public:
     bool getFTDriverInfo (int* major, int* minor, int* patch);
     bool getFTLibInfo (int* major, int* minor, int* patch);
 
+    bool getAcquisitionClockHz (uint32_t*) const;
+
     bool enableI2cMode (bool[4]);
     bool isI2cCapable (const uint32_t);
     bool isBnoConnected (const uint32_t);

--- a/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
+++ b/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
@@ -35,11 +35,11 @@
 
 #define INIT_STEP (evalBoard->isUSB3() ? 256 : 60)
 
-AcqBoardOpalKelly::AcqBoardOpalKelly (DataBuffer* buffer_) : AcquisitionBoard (buffer_),
-                                                             chipRegisters (30000.0f)
+AcqBoardOpalKelly::AcqBoardOpalKelly() : AcquisitionBoard(),
+                                         chipRegisters (30000.0f)
 {
     impedanceMeter = std::make_unique<ImpedanceMeterOpalKelly> (this);
-    
+
     evalBoard = std::make_unique<Rhd2000EvalBoard>();
 
     memset (auxBuffer, 0, sizeof (auxBuffer));
@@ -97,8 +97,8 @@ bool AcqBoardOpalKelly::detectBoard()
     {
         LOGC ("Board opened successfully.");
 
-            // Get some general information about the XEM.
-        LOGC("FPGA system clock: ", evalBoard->getSystemClockFreq(), " MHz"); // Should indicate 100 MHz
+        // Get some general information about the XEM.
+        LOGC ("FPGA system clock: ", evalBoard->getSystemClockFreq(), " MHz"); // Should indicate 100 MHz
         LOGC ("Opal Kelly device firmware version: ", evalBoard->dev->GetDeviceMajorVersion(), ".", evalBoard->dev->GetDeviceMinorVersion());
         LOGC ("Opal Kelly device serial number: ", evalBoard->dev->GetSerialNumber().c_str());
         LOGC ("Opal Kelly device ID std::string: ", evalBoard->dev->GetDeviceID().c_str());
@@ -221,7 +221,7 @@ Array<const Headstage*> AcqBoardOpalKelly::getHeadstages()
 {
     Array<const Headstage*> connectedHeadstages;
 
-    for(auto headstage : headstages)
+    for (auto headstage : headstages)
     {
         if (headstage->isConnected())
             connectedHeadstages.add (headstage);
@@ -257,7 +257,6 @@ Array<int> AcqBoardOpalKelly::getAvailableSampleRates()
 
 void AcqBoardOpalKelly::setSampleRate (int desiredSampleRate)
 {
-
     Rhd2000EvalBoard::AmplifierSampleRate sampleRate;
 
     switch (desiredSampleRate)
@@ -466,7 +465,6 @@ int AcqBoardOpalKelly::getIntanChipId (Rhd2000DataBlock* dataBlock, int stream, 
 
 void AcqBoardOpalKelly::scanPorts()
 {
-
     //Clear previous known streams
     enabledStreams.clear();
 
@@ -725,7 +723,6 @@ void AcqBoardOpalKelly::setCableLength (int hsNum, float length)
     }
 }
 
-
 bool AcqBoardOpalKelly::enableHeadstage (int hsNum, bool enabled, int nStr, int strChans)
 {
     LOGD ("Headstage ", hsNum, ", enabled: ", enabled, ", num streams: ", nStr, ", stream channels: ", strChans);
@@ -768,8 +765,6 @@ bool AcqBoardOpalKelly::enableHeadstage (int hsNum, bool enabled, int nStr, int 
 
         headstages[hsNum]->setNumStreams (0);
     }
-
-    buffer->resize (getNumChannels(), 10000);
 
     return true;
 }
@@ -828,7 +823,6 @@ void AcqBoardOpalKelly::measureImpedances()
 
 void AcqBoardOpalKelly::impedanceMeasurementFinished()
 {
-    
     if (impedances.valid)
     {
         LOGD ("Updating headstage impedance values");
@@ -843,7 +837,7 @@ void AcqBoardOpalKelly::impedanceMeasurementFinished()
 
         editor->impedanceMeasurementFinished();
     }
- }
+}
 
 void AcqBoardOpalKelly::saveImpedances (File& file)
 {
@@ -873,7 +867,7 @@ void AcqBoardOpalKelly::saveImpedances (File& file)
             xml->addChildElement (headstageXml);
         }
 
-       xml->writeTo(file, XmlElement::TextFormat());
+        xml->writeTo (file, XmlElement::TextFormat());
     }
 }
 
@@ -895,7 +889,6 @@ ChannelNamingScheme AcqBoardOpalKelly::getNamingScheme()
 void AcqBoardOpalKelly::enableAuxChannels (bool enabled)
 {
     settings.acquireAux = enabled;
-    buffer->resize (getNumChannels(), 10000);
     updateRegisters();
 }
 
@@ -907,7 +900,6 @@ bool AcqBoardOpalKelly::areAuxChannelsEnabled() const
 void AcqBoardOpalKelly::enableAdcChannels (bool enabled)
 {
     settings.acquireAdc = enabled;
-    buffer->resize (getNumChannels(), 10000);
 }
 
 bool AcqBoardOpalKelly::areAdcChannelsEnabled() const
@@ -917,7 +909,6 @@ bool AcqBoardOpalKelly::areAdcChannelsEnabled() const
 
 double AcqBoardOpalKelly::setUpperBandwidth (double upper)
 {
-
     settings.analogFilter.upperBandwidth = upper;
 
     updateRegisters();
@@ -927,7 +918,6 @@ double AcqBoardOpalKelly::setUpperBandwidth (double upper)
 
 double AcqBoardOpalKelly::setLowerBandwidth (double lower)
 {
-
     settings.analogFilter.lowerBandwidth = lower;
 
     updateRegisters();
@@ -937,7 +927,6 @@ double AcqBoardOpalKelly::setLowerBandwidth (double lower)
 
 double AcqBoardOpalKelly::setDspCutoffFreq (double freq)
 {
-
     settings.dsp.cutoffFreq = freq;
 
     updateRegisters();
@@ -952,7 +941,6 @@ double AcqBoardOpalKelly::getDspCutoffFreq() const
 
 void AcqBoardOpalKelly::setDspOffset (bool state)
 {
-
     settings.dsp.enabled = state;
 
     updateRegisters();
@@ -1033,7 +1021,6 @@ int AcqBoardOpalKelly::setClockDivider (int divide_ratio)
     return divide_ratio;
 }
 
-
 void AcqBoardOpalKelly::setDACTriggerThreshold (int dacChannelIndex, float threshold)
 {
     dacThresholds.set (dacChannelIndex, threshold);
@@ -1045,7 +1032,6 @@ void AcqBoardOpalKelly::setDACTriggerThreshold (int dacChannelIndex, float thres
 
 void AcqBoardOpalKelly::connectHeadstageChannelToDAC (int headstageChannelIndex, int dacChannelIndex)
 {
-
     if (dacChannelIndex == -1)
         return;
 
@@ -1078,7 +1064,7 @@ bool AcqBoardOpalKelly::isReady()
 bool AcqBoardOpalKelly::startAcquisition()
 {
     impedanceMeter->waitSafely();
-    dataBlock.reset( new Rhd2000DataBlock(evalBoard->getNumEnabledDataStreams(), evalBoard->isUSB3()));
+    dataBlock.reset (new Rhd2000DataBlock (evalBoard->getNumEnabledDataStreams(), evalBoard->isUSB3()));
 
     LOGD ("Expecting ", getNumChannels(), " channels.");
 
@@ -1244,9 +1230,8 @@ void AcqBoardOpalKelly::run()
                         channel++;
                         // ADC waveform units = volts
 
-
                         thisSample[channel] = getBitVolts (ContinuousChannel::ADC) * float (*(uint16*) (bufferPtr + index)) - 5 - 0.4096;
-                        
+
                         index += 2; // single chan width (2 bytes)
                     }
                 }
@@ -1260,10 +1245,10 @@ void AcqBoardOpalKelly::run()
                 index += 4;
 
                 buffer->addToBuffer (thisSample,
-                                               &timestamp,
-                                               &ts,
-                                               &ttlEventWord,
-                                               1);
+                                     &timestamp,
+                                     &ts,
+                                     &ttlEventWord,
+                                     1);
             }
         }
 
@@ -1274,7 +1259,7 @@ void AcqBoardOpalKelly::run()
             {
                 if (dacChannelsToUpdate[k])
                 {
-                    dacChannelsToUpdate.set(k, false);
+                    dacChannelsToUpdate.set (k, false);
                     if (dacChannels[k] >= 0)
                     {
                         evalBoard->enableDac (k, true);
@@ -1324,8 +1309,6 @@ void AcqBoardOpalKelly::run()
         }
     }
 }
-
-
 
 void AcqBoardOpalKelly::setNumHeadstageChannels (int hsNum, int numChannels)
 {
@@ -1402,7 +1385,6 @@ int AcqBoardOpalKelly::getNumDataOutputs (ContinuousChannel::Type type)
 
     return 0;
 }
-
 
 int AcqBoardOpalKelly::getChannelFromHeadstage (int hs, int ch)
 {

--- a/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
+++ b/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
@@ -1070,6 +1070,11 @@ void AcqBoardOpalKelly::connectHeadstageChannelToDAC (int headstageChannelIndex,
     }
 }
 
+bool AcqBoardOpalKelly::isReady()
+{
+    return true;
+}
+
 bool AcqBoardOpalKelly::startAcquisition()
 {
     impedanceMeter->waitSafely();

--- a/Source/devices/opalkelly/AcqBoardOpalKelly.h
+++ b/Source/devices/opalkelly/AcqBoardOpalKelly.h
@@ -115,6 +115,8 @@ public:
     /** Gets the method for determining channel names*/
     ChannelNamingScheme getNamingScheme();
 
+    bool isReady() override;
+
     /** Initializes data transfer*/
     bool startAcquisition();
 

--- a/Source/devices/opalkelly/AcqBoardOpalKelly.h
+++ b/Source/devices/opalkelly/AcqBoardOpalKelly.h
@@ -56,7 +56,7 @@ class AcqBoardOpalKelly : public AcquisitionBoard
     
 public:
     /** Constructor */
-    AcqBoardOpalKelly (DataBuffer* buffer_);
+    AcqBoardOpalKelly();
 
     /** Destructor */
     virtual ~AcqBoardOpalKelly();

--- a/Source/devices/simulated/AcqBoardSim.cpp
+++ b/Source/devices/simulated/AcqBoardSim.cpp
@@ -194,6 +194,11 @@ ChannelNamingScheme AcqBoardSim::getNamingScheme()
     return channelNamingScheme;
 }
 
+bool AcqBoardSim::isReady()
+{
+    return true;
+}
+
 bool AcqBoardSim::startAcquisition()
 {
     startThread();

--- a/Source/devices/simulated/AcqBoardSim.cpp
+++ b/Source/devices/simulated/AcqBoardSim.cpp
@@ -24,7 +24,7 @@
 
 const int MAX_NUM_HEADSTAGES = 8;
 
-AcqBoardSim::AcqBoardSim (DataBuffer* buffer_) : AcquisitionBoard (buffer_)
+AcqBoardSim::AcqBoardSim () : AcquisitionBoard ()
 {
     impedanceMeter = std::make_unique<ImpedanceMeterSim> ();
 
@@ -103,9 +103,6 @@ void AcqBoardSim::scanPorts()
             enableHeadstage (i, false);
 		}
     }
-
-    buffer->resize (getNumChannels(), 10000);
-        
 }
 
 
@@ -125,16 +122,12 @@ bool AcqBoardSim::enableHeadstage (int hsNum, bool enabled, int nStr, int strCha
         headstages[hsNum]->setChannelCount (0);
     }
 
-    buffer->resize (getNumChannels(), 10000);
-
     return true;
 }
 
 void AcqBoardSim::enableAuxChannels (bool enabled)
 {
     settings.acquireAux = enabled;
-
-    buffer->resize (getNumChannels(), 10000);
 }
 
 bool AcqBoardSim::areAuxChannelsEnabled() const
@@ -145,8 +138,6 @@ bool AcqBoardSim::areAuxChannelsEnabled() const
 void AcqBoardSim::enableAdcChannels (bool enabled)
 {
     settings.acquireAdc = enabled;
-
-    buffer->resize (getNumChannels(), 10000);
 }
 
 bool AcqBoardSim::areAdcChannelsEnabled() const

--- a/Source/devices/simulated/AcqBoardSim.h
+++ b/Source/devices/simulated/AcqBoardSim.h
@@ -42,7 +42,7 @@ class AcqBoardSim : public AcquisitionBoard
 {
 public:
     /** Constructor */
-    AcqBoardSim (DataBuffer* buffer_);
+    AcqBoardSim ();
 
     /** Destructor */
     virtual ~AcqBoardSim();

--- a/Source/devices/simulated/AcqBoardSim.h
+++ b/Source/devices/simulated/AcqBoardSim.h
@@ -101,6 +101,8 @@ public:
     /** Gets the method for determining channel names*/
     ChannelNamingScheme getNamingScheme();
 
+    bool isReady() override;
+
     /** Initializes data transfer*/
     bool startAcquisition();
 


### PR DESCRIPTION
This PR is focused on adding BNO functionality.

When a BNO is detected, the editor now displays "IMU" where the channel numbers usually appear. If there are no other ephys channels, this is displayed in the left position in that port.

Fixes #6 

Fixed a use case where the data would not stream if there were no ephys channels (and no AUX or ADC channels either). Now it correctly can detect if there is a BNO present, and will stream to the correct buffers accordingly. 

Fixes #21 

Only show the channel columns in the canvas when there are ephys channels.

Set the memory monitor sample rate, and use the same rate when setting the stream so they are not misaligned.

Other various code cleanups and additions.