### PR TITLE
Add MemoryMonitor usage indicator to editor 

### DIFF
--- a/Source/DeviceEditor.cpp
+++ b/Source/DeviceEditor.cpp
@@ -61,19 +61,33 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
 
     board->editor = this;
 
+    int xOffset = 0;
+
+    if (board->getBoardType() == AcquisitionBoard::BoardType::ONI)
+    {
+        desiredWidth += 22;
+
+        memoryUsage = std::make_unique<MemoryMonitorUsage> (parentNode);
+        memoryUsage->setBounds (8, 30, 15, 95);
+        memoryUsage->setTooltip ("Monitors the percent of the hardware memory buffer used.");
+        addAndMakeVisible (memoryUsage.get());
+
+        xOffset = memoryUsage->getRight();
+    }
+
     // add headstage-specific controls (currently just a toggle button)
     for (int i = 0; i < 4; i++)
     {
         HeadstageOptionsInterface* hsOptions = new HeadstageOptionsInterface (board, this, i);
         headstageOptionsInterfaces.add (hsOptions);
         addAndMakeVisible (hsOptions);
-        hsOptions->setBounds (3, 28 + i * 20, 70, 18);
+        hsOptions->setBounds (xOffset + 3, 28 + i * 20, 70, 18);
     }
 
     // add rescan button
     rescanButton = std::make_unique<UtilityButton> ("RESCAN");
     rescanButton->setRadius (3.0f);
-    rescanButton->setBounds (6, 108, 65, 18);
+    rescanButton->setBounds (xOffset + 6, 108, 65, 18);
     rescanButton->addListener (this);
     rescanButton->setTooltip ("Check for connected headstages");
     addAndMakeVisible (rescanButton.get());
@@ -81,17 +95,17 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
     // add sample rate selection
     sampleRateInterface = std::make_unique<SampleRateInterface> (board, this);
     addAndMakeVisible (sampleRateInterface.get());
-    sampleRateInterface->setBounds (80, 20, 80, 50);
+    sampleRateInterface->setBounds (xOffset + 80, 20, 80, 50);
 
     // add Bandwidth selection
     bandwidthInterface = std::make_unique<BandwidthInterface> (board, this);
     addAndMakeVisible (bandwidthInterface.get());
-    bandwidthInterface->setBounds (80, 55, 80, 50);
+    bandwidthInterface->setBounds (xOffset + 80, 55, 80, 50);
 
     // add AUX channel enable/disable button
     auxButton = std::make_unique<UtilityButton> ("AUX");
     auxButton->setRadius (3.0f);
-    auxButton->setBounds (80, 108, 32, 18);
+    auxButton->setBounds (xOffset + 80, 108, 32, 18);
     auxButton->addListener (this);
     auxButton->setClickingTogglesState (true);
     auxButton->setTooltip ("Toggle AUX channels (3 per headstage)");
@@ -100,7 +114,7 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
     // add ADC channel enable/disable button
     adcButton = std::make_unique<UtilityButton> ("ADC");
     adcButton->setRadius (3.0f);
-    adcButton->setBounds (80 + 32 + 1, 108, 32, 18);
+    adcButton->setBounds (xOffset + 80 + 32 + 1, 108, 32, 18);
     adcButton->addListener (this);
     adcButton->setClickingTogglesState (true);
     adcButton->setTooltip ("Toggle 8 external HDMI ADC channels");
@@ -108,7 +122,7 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
 
     // add audio output config interface
     audioLabel = std::make_unique<Label> ("audio label", "Audio out");
-    audioLabel->setBounds (170, 20, 75, 15);
+    audioLabel->setBounds (xOffset + 170, 20, 75, 15);
     audioLabel->setFont (Font ("Small Text", 10, Font::plain));
     addAndMakeVisible (audioLabel.get());
 
@@ -117,7 +131,7 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
         ElectrodeButton* button = new ElectrodeButton (-1);
         electrodeButtons.add (button);
 
-        button->setBounds (174 + i * 30, 35, 30, 15);
+        button->setBounds (xOffset + 174 + i * 30, 35, 30, 15);
         button->setChannelNum (-1);
         button->setClickingTogglesState (false);
         button->setToggleState (false, dontSendNotification);
@@ -138,16 +152,16 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
     // add HW audio parameter selection
     audioInterface = std::make_unique<AudioInterface> (board, this);
     addAndMakeVisible (audioInterface.get());
-    audioInterface->setBounds (174, 55, 70, 50);
+    audioInterface->setBounds (xOffset + 174, 55, 70, 50);
 
     clockInterface = std::make_unique<ClockDivideInterface> (board, this);
     addAndMakeVisible (clockInterface.get());
-    clockInterface->setBounds (174, 80, 70, 50);
+    clockInterface->setBounds (xOffset + 174, 80, 70, 50);
 
     // add DSP Offset Button
     dspoffsetButton = std::make_unique<UtilityButton> ("DSP:");
     dspoffsetButton->setRadius (3.0f); // sets the radius of the button's corners
-    dspoffsetButton->setBounds (174, 108, 32, 18); // sets the x position, y position, width, and height of the button
+    dspoffsetButton->setBounds (xOffset + 174, 108, 32, 18); // sets the x position, y position, width, and height of the button
     dspoffsetButton->addListener (this);
     dspoffsetButton->setClickingTogglesState (true); // makes the button toggle its state when clicked
     dspoffsetButton->setTooltip ("Toggle DSP offset removal");
@@ -157,11 +171,11 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
     // add DSP Frequency Selection field
     dspInterface = std::make_unique<DSPInterface> (board, this);
     addAndMakeVisible (dspInterface.get());
-    dspInterface->setBounds (174 + 32, 108, 40, 50);
+    dspInterface->setBounds (xOffset + 174 + 32, 108, 40, 50);
 
     dacTTLButton = std::make_unique<UtilityButton> ("DAC TTL");
     dacTTLButton->setRadius (3.0f);
-    dacTTLButton->setBounds (260, 25, 60, 18);
+    dacTTLButton->setBounds (xOffset + 260, 25, 60, 18);
     dacTTLButton->addListener (this);
     dacTTLButton->setClickingTogglesState (true);
     dacTTLButton->setTooltip ("Toggle DAC Threshold TTL Output");
@@ -169,11 +183,11 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
 
     dacHPFlabel = std::make_unique<Label> ("DAC HPF", "DAC HPF");
     dacHPFlabel->setFont (Font ("Small Text", 10, Font::plain));
-    dacHPFlabel->setBounds (255, 40, 60, 20);
+    dacHPFlabel->setBounds (xOffset + 255, 40, 60, 20);
     addAndMakeVisible (dacHPFlabel.get());
 
     dacHPFcombo = std::make_unique<ComboBox> ("dacHPFCombo");
-    dacHPFcombo->setBounds (260, 55, 60, 18);
+    dacHPFcombo->setBounds (xOffset + 260, 55, 60, 18);
     dacHPFcombo->addListener (this);
     dacHPFcombo->addItem ("OFF", 1);
     int HPFvalues[10] = { 50, 100, 200, 300, 400, 500, 600, 700, 800, 900 };
@@ -186,11 +200,11 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
 
     ttlSettleLabel = std::make_unique<Label> ("TTL Settle", "TTL Settle");
     ttlSettleLabel->setFont (Font ("Small Text", 10, Font::plain));
-    ttlSettleLabel->setBounds (255, 70, 70, 20);
+    ttlSettleLabel->setBounds (xOffset + 255, 70, 70, 20);
     addAndMakeVisible (ttlSettleLabel.get());
 
     ttlSettleCombo = std::make_unique<ComboBox> ("FastSettleComboBox");
-    ttlSettleCombo->setBounds (260, 85, 60, 18);
+    ttlSettleCombo->setBounds (xOffset + 260, 85, 60, 18);
     ttlSettleCombo->addListener (this);
     ttlSettleCombo->addItem ("-", 1);
     for (int k = 0; k < 8; k++)
@@ -202,7 +216,7 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
 
     ledButton = std::make_unique<UtilityButton> ("LED");
     ledButton->setRadius (3.0f);
-    ledButton->setBounds (288, 108, 32, 18);
+    ledButton->setBounds (xOffset + 288, 108, 32, 18);
     ledButton->addListener (this);
     ledButton->setClickingTogglesState (true);
     ledButton->setTooltip ("Toggle board LEDs");
@@ -380,6 +394,9 @@ void DeviceEditor::startAcquisition()
         canvas->beginAnimation();
     }
 
+    if(memoryUsage != nullptr)
+        memoryUsage->startAcquisition();
+
     acquisitionIsActive = true;
 }
 
@@ -399,6 +416,9 @@ void DeviceEditor::stopAcquisition()
     {
         canvas->endAnimation();
     }
+
+    if (memoryUsage != nullptr)
+        memoryUsage->stopAcquisition();
 
     acquisitionIsActive = false;
 }

--- a/Source/DeviceEditor.h
+++ b/Source/DeviceEditor.h
@@ -24,6 +24,7 @@
 #ifndef __DEVICEEDITOR_H_2AD3C591__
 #define __DEVICEEDITOR_H_2AD3C591__
 
+#include "UI/MemoryMonitorUsage.h"
 #include <VisualizerEditorHeaders.h>
 
 class HeadstageOptionsInterface;
@@ -91,6 +92,12 @@ public:
 
     virtual Array<int> getSelectedChannels() { return Array<int>(); }
 
+    void setPercentMemoryUsed (float memoryUsed)
+    {
+        if (memoryUsage != nullptr)
+            memoryUsage->setPercentMemoryUsed (memoryUsed);
+    }
+
 private:
     /** Pointer to acquisition board device */
     class AcquisitionBoard* board;
@@ -100,6 +107,8 @@ private:
 
     /** XmlElement to hold previously saved parameters if no device is found */
     std::unique_ptr<XmlElement> previousSettings;
+
+    std::unique_ptr<MemoryMonitorUsage> memoryUsage = nullptr;
 
     OwnedArray<HeadstageOptionsInterface> headstageOptionsInterfaces;
     OwnedArray<ElectrodeButton> electrodeButtons;

--- a/Source/UI/MemoryMonitorUsage.cpp
+++ b/Source/UI/MemoryMonitorUsage.cpp
@@ -1,0 +1,53 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2024 Open Ephys
+
+    ------------------------------------------------------------------
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "MemoryMonitorUsage.h"
+
+MemoryMonitorUsage::MemoryMonitorUsage (GenericProcessor* p)
+    : LevelMonitor (p)
+{
+    percentMemoryUsed = 0.0f;
+}
+
+void MemoryMonitorUsage::timerCallback()
+{
+    setFillPercentage (std::log (percentMemoryUsed + 1) / maxLogarithmicValue);
+    repaint();
+}
+
+void MemoryMonitorUsage::setPercentMemoryUsed (float memoryUsed)
+{
+    percentMemoryUsed = memoryUsed;
+}
+
+void MemoryMonitorUsage::startAcquisition()
+{
+    startTimerHz (TimerFrequencyHz);
+}
+
+void MemoryMonitorUsage::stopAcquisition()
+{
+    stopTimer();
+    setFillPercentage (0.0f);
+    repaint();
+}

--- a/Source/UI/MemoryMonitorUsage.h
+++ b/Source/UI/MemoryMonitorUsage.h
@@ -1,0 +1,54 @@
+/*
+    ------------------------------------------------------------------
+
+    This file is part of the Open Ephys GUI
+    Copyright (C) 2024 Open Ephys
+
+    ------------------------------------------------------------------
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#pragma once
+
+#include <VisualizerEditorHeaders.h>
+
+/*
+	Tracks the MemoryMonitor usage while data acquisition is running
+*/
+class MemoryMonitorUsage : public LevelMonitor
+{
+public:
+    MemoryMonitorUsage (GenericProcessor*);
+
+    void timerCallback() override;
+
+    void startAcquisition();
+
+    void stopAcquisition();
+
+    void setPercentMemoryUsed (float memoryUsed);
+
+private:
+    std::atomic<float> percentMemoryUsed;
+
+    // NB: Calculate the maximum logarithmic value to convert from linear scale (x: 0-100) to logarithmic scale (y: 0-1)
+    //	   using the following equation: y = log_e(x + 1) / log_e(x_max + 1);
+    const float maxLogarithmicValue = std::log (101);
+
+    const int TimerFrequencyHz = 10;
+
+    JUCE_LEAK_DETECTOR (MemoryMonitorUsage);
+};

--- a/Source/devices/AcquisitionBoard.h
+++ b/Source/devices/AcquisitionBoard.h
@@ -208,6 +208,16 @@ public:
         return buffer;
     }
 
+    enum class BoardType
+    {
+        None = 0,
+        Simulated = 1,
+        OpalKelly = 2,
+        ONI = 3
+    };
+
+    BoardType getBoardType() const { return boardType; }
+
 protected:
     /** Timer for triggering digital outputs */
     class DigitalOutputTimer : public Timer
@@ -340,6 +350,8 @@ protected:
 
     /** True if change in settings is needed during acquisition*/
     bool updateSettingsDuringAcquisition = false;
+
+    BoardType boardType = BoardType::None;
 };
 
 #endif

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -29,6 +29,8 @@ const double quat_scale = (1.0f / (1 << 14));
 AcqBoardONI::AcqBoardONI() : AcquisitionBoard(),
                              chipRegisters (30000.0f)
 {
+    boardType = BoardType::ONI;
+
     impedanceMeter = std::make_unique<ImpedanceMeterONI> (this);
 
     evalBoard = std::make_unique<Rhd2000ONIBoard>();
@@ -1622,6 +1624,8 @@ void AcqBoardONI::run()
                     &tsd,
                     &zero,
                     1);
+
+                editor->setPercentMemoryUsed (memf);
             }
             else if (hasBNO[0] && frame->dev_idx == Rhd2000ONIBoard::DEVICE_BNO_A)
             {

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -60,6 +60,8 @@ AcqBoardONI::AcqBoardONI() : AcquisitionBoard(),
         hasBNO[i] = false;
         bnoBuffers.add (nullptr);
     }
+
+    isTransmitting = false;
 }
 
 AcqBoardONI::~AcqBoardONI()

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -390,18 +390,33 @@ bool Rhd2000ONIBoard::setMemoryMonitorSampleRate (int sampleRate)
     oni_reg_val_t clkHz;
     int rc = oni_read_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::CLK_HZ, &clkHz);
     if (rc != ONI_ESUCCESS)
+    {
+        std::cout << oni_error_str (rc) << "\n";
         return false;
+    }
 
     rc = oni_write_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::CLK_DIV, clkHz / sampleRate);
 
-    return rc == ONI_ESUCCESS;
+    if (rc != ONI_ESUCCESS)
+    {
+        std::cout << oni_error_str (rc) << "\n";
+        return false;
+    }
+
+    return true;
 }
 
 bool Rhd2000ONIBoard::getTotalMemory(uint32_t* memory)
 {
     int rc = oni_read_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::TOTAL_MEM, memory);
 
-    return rc == ONI_ESUCCESS;
+    if (rc != ONI_ESUCCESS)
+    {
+        std::cout << oni_error_str (rc) << "\n";
+        return false;
+    }
+
+    return true;
 }
 
 // Print a command list to the console in readable form.

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1312,7 +1312,7 @@ uint32_t Rhd2000ONIBoard::getDeviceIdOnEeprom (const uint32_t port)
             return 0;
     }
 
-    const uint32_t deviceIdStartAddress = 7;
+    const uint32_t deviceIdStartAddress = 8;
     uint32_t data = 0;
 
     for (unsigned int i = 0; i < sizeof (uint32_t); i++)

--- a/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
+++ b/Source/devices/opalkelly/AcqBoardOpalKelly.cpp
@@ -38,6 +38,8 @@
 AcqBoardOpalKelly::AcqBoardOpalKelly() : AcquisitionBoard(),
                                          chipRegisters (30000.0f)
 {
+    boardType = BoardType::OpalKelly;
+
     impedanceMeter = std::make_unique<ImpedanceMeterOpalKelly> (this);
 
     evalBoard = std::make_unique<Rhd2000EvalBoard>();

--- a/Source/devices/simulated/AcqBoardSim.cpp
+++ b/Source/devices/simulated/AcqBoardSim.cpp
@@ -26,6 +26,8 @@ const int MAX_NUM_HEADSTAGES = 8;
 
 AcqBoardSim::AcqBoardSim () : AcquisitionBoard ()
 {
+    boardType = BoardType::Simulated;
+
     impedanceMeter = std::make_unique<ImpedanceMeterSim> ();
 
     for (int i = 0; i < MAX_NUM_HEADSTAGES; i++)


### PR DESCRIPTION
Add a `BoardType` member so that different boards can be easily identified.
Shift the editor over if the board is of type `ONI`, so there is room for the memory monitor level component.

Fixes #22 
Fixes #24 