### PR TITLE
Detect board version

### DIFF
--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -297,6 +297,14 @@ private:
     /** Re-check cable delays after changing sample rate*/
     bool checkCableDelays = false;
 
+    /** Hold the current device ID.Used to determine which version of the acquisition board this is */
+    int deviceId = 0;
+
+    static constexpr int DEVICE_ID_V2 = 0x0100;
+    static constexpr int DEVICE_ID_V3 = 0x0102;
+
+    static constexpr double v3AdcBitVal = double ((((1.25 * (1 + 84.5 / 51)) / (1 << 12)) * (10 / (1.25 * (1 + 84.5 / 51)))) / 16);
+
     static constexpr int NUMBER_OF_PORTS = 4;
     static constexpr int BNO_CHANNELS = 4;
     static constexpr int MEMORY_MONITOR_FS = 100;

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1165,13 +1165,13 @@ void Rhd2000ONIBoard::setDacManual (int value)
         return;
     }
     value = value & 0xFFFF;
-    oni_size_t values[4];
+    oni_size_t dacValues[4] {};
     for (int i = 0; i < 4; i++)
     {
-        values[i] = value + (value << 16);
+        dacValues[i] = std::min ((value + 5) / (10 * bitVal16), static_cast<double> (std::numeric_limits<uint16_t>::max()));
     }
     oni_frame_t* frame;
-    int res = oni_create_frame (ctx, &frame, DEVICE_DAC, values, 4 * sizeof (oni_size_t));
+    int res = oni_create_frame (ctx, &frame, DEVICE_DAC, dacValues, 4 * sizeof (oni_size_t));
     if (res > ONI_ESUCCESS)
     {
         oni_write_frame (ctx, frame);
@@ -1192,6 +1192,15 @@ bool Rhd2000ONIBoard::getFirmwareVersion (int* major, int* minor, int* patch) co
     *minor = (val >> 8) & 0xFF;
     *major = (val >> 16) & 0xFF;
     return true;
+}
+
+bool Rhd2000ONIBoard::getDeviceId(oni_reg_val_t* id)
+{
+    constexpr int deviceIndex = 254;
+    constexpr int registerAddress = 0;
+    int rc = oni_read_reg (ctx, deviceIndex, registerAddress, id);
+
+    return rc == ONI_ESUCCESS;
 }
 
 Rhd2000ONIBoard::BoardMemState Rhd2000ONIBoard::getBoardMemState() const

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -165,6 +165,7 @@ public:
     void getONIDriverInfo (const oni_driver_info_t** driverInfo);
     bool getFTDriverInfo (int* major, int* minor, int* patch);
     bool getFTLibInfo (int* major, int* minor, int* patch);
+    bool getDeviceId (oni_reg_val_t* id);
 
     bool getAcquisitionClockHz (uint32_t*) const;
 
@@ -275,4 +276,6 @@ private:
     int numDataStreams; // total number of data streams currently enabled
     int dataStreamEnabled[MAX_NUM_DATA_STREAMS_USB3]; // 0 (disabled) or 1 (enabled), set for maximum stream number
     std::vector<int> cableDelay;
+
+    static constexpr double bitVal16 = double (1 / double (1 << 16));
 };


### PR DESCRIPTION
Add method to check the device ID when opening the board, where the old version is 0x0100, and the new version is 0x0102. For V3, modify how the ADC/DAC values are handled (see the issue for more details).

Fixes #23 