### PR TITLE
Read EEPROM id in v1 and v2 of the format

### DIFF
--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1301,28 +1301,31 @@ uint32_t Rhd2000ONIBoard::getDeviceIdOnEeprom (const uint32_t port)
     if (!ctx || port > 3)
         return 0;
 
+    uint8_t val;
+    int res;
+
     oni_dev_idx_t i2cRawAddress = DEVICE_I2C_RAW_A + port * 2;
 
-    // NB: Confirm EEPROM first bytes contain OESH\x01
-    const char identifier[] = "OESH\x01";
+    // NB: Confirm EEPROM first bytes contain OESH
+    const char identifier[] = "OESH";
 
     for (unsigned int i = 0; i < strlen(identifier); i += 1)
-    {
-        uint8_t val;
-        int res;
+    {    
         res = readEepromByte (i2cRawAddress, i, val);
 
         if (res != 0 || val != identifier[i])
             return 0;
     }
+    //Check that EEPROM format is v1 or v2
+    res = readEepromByte (i2cRawAddress, 4, val);
+    if (res != 0 || (val != 1 && val != 2))
+        return 0;
 
     const uint32_t deviceIdStartAddress = 8;
     uint32_t data = 0;
 
     for (unsigned int i = 0; i < sizeof (uint32_t); i++)
     {
-        uint8_t val;
-        int res;
         res = readEepromByte (i2cRawAddress, deviceIdStartAddress + i, val);
 
         if (res != 0)


### PR DESCRIPTION
The EEPROM format for headstages in open-ephys/oe-acquisition-board-v3#34 has been updated to a v2 including a checksum. Since the software does not use the checksum for now, and the rest of the format is the same, the board needs to be able to work with both.