### PR TITLE
Only enable memory monitor for firmware >= v1.5.1

### DIFF
--- a/Source/DeviceEditor.cpp
+++ b/Source/DeviceEditor.cpp
@@ -24,6 +24,7 @@
 #include "DeviceEditor.h"
 
 #include "devices/AcquisitionBoard.h"
+#include "devices/oni/AcqBoardONI.h"
 
 #include "UI/ChannelCanvas.h"
 
@@ -65,14 +66,17 @@ DeviceEditor::DeviceEditor (GenericProcessor* parentNode,
 
     if (board->getBoardType() == AcquisitionBoard::BoardType::ONI)
     {
-        desiredWidth += 22;
+        if (((AcqBoardONI*)board)->getMemoryMonitorSupport())
+        {
+            desiredWidth += 22;
 
-        memoryUsage = std::make_unique<MemoryMonitorUsage> (parentNode);
-        memoryUsage->setBounds (8, 30, 15, 95);
-        memoryUsage->setTooltip ("Monitors the percent of the hardware memory buffer used.");
-        addAndMakeVisible (memoryUsage.get());
+            memoryUsage = std::make_unique<MemoryMonitorUsage> (parentNode);
+            memoryUsage->setBounds (8, 30, 15, 95);
+            memoryUsage->setTooltip ("Monitors the percent of the hardware memory buffer used.");
+            addAndMakeVisible (memoryUsage.get());
 
-        xOffset = memoryUsage->getRight();
+            xOffset = memoryUsage->getRight();
+        }
     }
 
     // add headstage-specific controls (currently just a toggle button)

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -212,6 +212,9 @@ public:
     /** Create stream and channel structures is the acquisition board type has custom streams and updates the buffers */
     void updateCustomStreams (OwnedArray<DataStream>& otherStreams, OwnedArray<ContinuousChannel>& otherChannels) override;
 
+    /** Gets whether or not the firmware version fully supports memory monitor data */
+    bool getMemoryMonitorSupport() const;
+
 private:
     /**Check board memory status */
     bool checkBoardMem() const;
@@ -321,11 +324,12 @@ private:
     bool hasI2c[NUMBER_OF_PORTS]; // Tracks if there is an I2C-capable device on any of the available ports
     uint32_t headstageId[NUMBER_OF_PORTS];
     bool hasI2cSupport = false;
+    bool hasMemoryMonitorSupport = false;
 
     uint32_t acquisitionClockHz;
     uint32_t totalMemory;
 
-    DataBuffer* memBuffer;
+    DataBuffer* memBuffer = nullptr;
     Array<DataBuffer*, juce::DummyCriticalSection, NUMBER_OF_PORTS> bnoBuffers;
 };
 

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -385,9 +385,9 @@ double Rhd2000ONIBoard::getSampleRate() const
     }
 }
 
-void Rhd2000ONIBoard::enableMemoryMonitor()
+void Rhd2000ONIBoard::enableMemoryMonitor(bool enable)
 {
-    int rc = oni_write_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::ENABLE, 1);
+    int rc = oni_write_reg (ctx, DEVICE_MEMORY, (oni_reg_addr_t) MemoryMonitorRegisters::ENABLE, enable ? 1 : 0);
 
     if (rc != ONI_ESUCCESS)
     {

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -126,7 +126,7 @@ public:
     bool setSampleRate (AmplifierSampleRate newSampleRate);
     double getSampleRate() const;
 
-    void enableMemoryMonitor();
+    void enableMemoryMonitor(bool enable = true);
     bool setMemoryMonitorSampleRate (int sampleRate);
     bool getTotalMemory (uint32_t*);
 


### PR DESCRIPTION
For firmware versions `< 1.5.1` there is an issue with how memory data is displayed. For clarity, we are disabling the memory monitor data stream and the corresponding memory usage monitor in the editor for lower firmware versions.