### PR TITLE
Ensure hardware timestamps are used when recording

### DIFF
--- a/Source/DeviceThread.cpp
+++ b/Source/DeviceThread.cpp
@@ -158,13 +158,14 @@ void DeviceThread::updateSettings (OwnedArray<ContinuousChannel>* continuousChan
     {
         sourceBuffers.add (acquisitionBoard->getBuffer());
 
+        bool generatesTimestamps = acquisitionBoard->getBoardType() == AcquisitionBoard::BoardType::ONI;
+
         DataStream::Settings dataStreamSettings {
             "acquisition_board",
             "Continuous and event data from an Open Ephys Acquisition Board",
             "acq-board.rhythm",
-
-            static_cast<float> (acquisitionBoard->getSampleRate())
-
+            static_cast<float> (acquisitionBoard->getSampleRate()),
+            generatesTimestamps
         };
 
         DataStream* stream = new DataStream (dataStreamSettings);

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "1.0.1";
+	info->libVersion = "1.1.0";
 	info->numPlugins = NUM_PLUGINS;
 }
 

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -273,7 +273,7 @@ private:
     int getHeadstageChannel (int& headstageIndex, int channelIndex) const;
 
     /** Adds the given frame to the corresponding BNO buffer */
-    void addBnoDataToBuffer (oni_frame_t*, DataBuffer*) const;
+    void addBnoDataToBuffer (oni_frame_t*, DataBuffer*, int64) const;
 
     /** Rhythm API classes*/
     std::unique_ptr<Rhd2000ONIBoard> evalBoard;
@@ -357,6 +357,10 @@ private:
 
     uint32_t acquisitionClockHz;
     uint32_t totalMemory;
+
+    int64 dataSampleNumber = 0;
+    int64 memorySampleNumber = 0;
+    std::array<int64, NUMBER_OF_PORTS> bnoSampleNumbers = { 0, 0, 0, 0 };
 
     DataBuffer* memBuffer = nullptr;
     Array<DataBuffer*, juce::DummyCriticalSection, NUMBER_OF_PORTS> bnoBuffers;

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <iomanip>
 #include <iostream>
+#include <thread>
+#include <chrono>
 
 Rhd2000ONIBoard::Rhd2000ONIBoard()
 {
@@ -609,6 +611,8 @@ void Rhd2000ONIBoard::selectAuxCommandLength (AuxCmdSlot auxCommandSlot, int loo
 
 void Rhd2000ONIBoard::resetBoard()
 {
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for (50ms);
     uint32_t val = 1;
     oni_set_opt (ctx, ONI_OPT_RESET, &val, sizeof (val));
     oni_set_opt (ctx, ONI_OPT_BLOCKREADSIZE, &usbReadBlockSize, sizeof (usbReadBlockSize));


### PR DESCRIPTION
This PR ensures that if hardware timestamps are being generated by the ONI acquisition board, they are respected by the record node. This is done by making sure that `generates_timestamps` is true in `DataStream::Settings`. 

Also corrects the sample numbers / timestamps being delivered from the data block in `AcqBoardONI`, as they were swapped and also uninitialized, leading to junk data being sent repeatedly.