### PR TITLE
Update workflows for CI/CD

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,42 +2,134 @@ name: linux
 
 on: 
   push:
+    branches: [main] # NB: Runs whenever a PR is merged to main
   pull_request:
+    branches: [main] # NB: Runs when a PR to main is opened. This can be expanded to run when PRs are opened to other branches (i.e., testing-juce8)
+  release:
+    types: [published] # NB: Runs whenever a new release is created. Releases are based on tags, but are separate in that a tag can be created without a concurrent release
 
 jobs:
 
+  check-semver:
+    runs-on: ubuntu-22.04
+    if: github.event_name != 'release'
+    steps:
+      - name: Checkout current version
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find previous release
+        id: previous-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "RELEASE_NAME=$(gh release list -L 1 --json tagName -q .[0].tagName)" >> $GITHUB_OUTPUT
+          
+      - name: Checkout last release version
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.previous-release.outputs.RELEASE_NAME }}
+          path: last-release
+          sparse-checkout: |
+            Source/OpenEphysLib.cpp
+          sparse-checkout-cone-mode: false
+
+      - name: Extract Versions
+        id: extract-versions
+        run: |
+          ls -la
+          ls last-release -la
+          ls last-release/Source -la
+          cat ./last-release/Source/OpenEphysLib.cpp
+          echo "CURRENT_VERSION=$(cat ./Source/OpenEphysLib.cpp | grep -w -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=$(cat ./last-release/Source/OpenEphysLib.cpp | grep -w -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> $GITHUB_OUTPUT
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.12"
+
+      - name: Install semver
+        run: python -m pip install semver
+
+      - name: Compare Versions
+        run: |
+         version_current=${{ steps.extract-versions.outputs.CURRENT_VERSION }}
+         version_release=${{ steps.extract-versions.outputs.PREVIOUS_VERSION }}
+ 
+         echo "Current Version: $version_current"
+         echo "Release Version: $version_release"
+         
+         if [ ! $(python -c "import semver; print(semver.compare(\"$version_current\", \"$version_release\"))") == 1 ]; then
+           echo "::error title=Invalid version number::Version number must be increased"
+           exit 1
+         fi
+
   build-linux:
 
+    needs: [check-semver]
+    if: always() && !failure() && !cancelled()
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-22.04]
+    outputs:
+      PLUGIN_API: ${{ steps.setup.outputs.PLUGIN_API }}
+      PLUGIN_VERSION: ${{ steps.setup.outputs.PLUGIN_VERSION }}
 
     steps:
     - uses: actions/checkout@v4
+
     - name: setup
+      id: setup
       run: |
         sudo apt update
         cd ../..
         git clone https://github.com/open-ephys/plugin-GUI.git --branch testing-juce8
         sudo ./plugin-GUI/Resources/Scripts/install_linux_dependencies.sh
         cd plugin-GUI/Build && cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
+        echo "PLUGIN_API=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)" >> GITHUB_OUTPUT
+        echo "PLUGIN_VERSION=$(grep -w ../Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> GITHUB_OUTPUT
+    
     - name: build
+      id: build
       run: |
         cd Build
         cmake -G "Unix Makefiles" -DCMAKE_BUILD_TYPE=Release ..
         make
-#    - name: test
-#      run: cd build && ctest
+        
+    - name: Collect artifact
+      uses: actions/upload-artifact@v4
+      if: steps.build.outcome == 'success' && always()
+      with:
+        name: Artifact
+        if-no-files-found: error
+        path: |
+          Build
+          Resources
+          libONI
+
+  deploy-linux:
+
+    needs: [build-linux]
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && always() && !failure() && !cancelled()
+
+    steps:
+
+    - name: Download build folder
+      uses: actions/download-artifact@v4
+      with:
+        name: Artifact
+
     - name: deploy
-      if: github.ref == 'refs/heads/main'
       env:
         ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
         build_dir: "Build"
         package: AcquisitionBoard-linux
       run: |
-        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
-        tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
+        plugin_api=${{ needs.build-linux.outputs.PLUGIN_API }}
+        tag=${{ needs.build-linux.outputs.PLUGIN_VERSION }}
         new_plugin_ver=$tag-API$plugin_api
         mkdir plugins 
         cp -r $build_dir/*.so plugins

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -2,33 +2,125 @@ name: mac
 
 on: 
   push:
+    branches: [main] # NB: Runs whenever a PR is merged to main
   pull_request:
+    branches: [main] # NB: Runs when a PR to main is opened. This can be expanded to run when PRs are opened to other branches (i.e., testing-juce8)
+  release:
+    types: [published] # NB: Runs whenever a new release is created. Releases are based on tags, but are separate in that a tag can be created without a concurrent release
 
 jobs:
 
+  check-semver:
+    runs-on: ubuntu-22.04
+    if: github.event_name != 'release'
+    steps:
+      - name: Checkout current version
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find previous release
+        id: previous-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "RELEASE_NAME=$(gh release list -L 1 --json tagName -q .[0].tagName)" >> $GITHUB_OUTPUT
+          
+      - name: Checkout last release version
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.previous-release.outputs.RELEASE_NAME }}
+          path: last-release
+          sparse-checkout: |
+            Source/OpenEphysLib.cpp
+          sparse-checkout-cone-mode: false
+
+      - name: Extract Versions
+        id: extract-versions
+        run: |
+          ls -la
+          ls last-release -la
+          ls last-release/Source -la
+          cat ./last-release/Source/OpenEphysLib.cpp
+          echo "CURRENT_VERSION=$(cat ./Source/OpenEphysLib.cpp | grep -w -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=$(cat ./last-release/Source/OpenEphysLib.cpp | grep -w -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> $GITHUB_OUTPUT
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.12"
+
+      - name: Install semver
+        run: python -m pip install semver
+
+      - name: Compare Versions
+        run: |
+         version_current=${{ steps.extract-versions.outputs.CURRENT_VERSION }}
+         version_release=${{ steps.extract-versions.outputs.PREVIOUS_VERSION }}
+ 
+         echo "Current Version: $version_current"
+         echo "Release Version: $version_release"
+         
+         if [ ! $(python -c "import semver; print(semver.compare(\"$version_current\", \"$version_release\"))") == 1 ]; then
+           echo "::error title=Invalid version number::Version number must be increased"
+           exit 1
+         fi
+
   build-mac:
 
+    needs: [check-semver]
+    if: always() && !failure() && !cancelled()
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest]
+    outputs:
+      PLUGIN_API: ${{ steps.setup.outputs.PLUGIN_API }}
+      PLUGIN_VERSION: ${{ steps.setup.outputs.PLUGIN_VERSION }}
 
     steps:
     - uses: actions/checkout@v4
+
     - name: setup
+      id: setup
       run: |
         cd ../..
         git clone https://github.com/open-ephys/plugin-GUI.git --branch testing-juce8
         cd plugin-GUI/Build && cmake -G "Xcode" ..
+        echo "PLUGIN_API=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)" >> GITHUB_OUTPUT
+        echo "PLUGIN_VERSION=$(grep -w ../Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> GITHUB_OUTPUT
+
     - name: build
+      id: build
       run: |
         cd Build
         cmake -G "Xcode" ..
         xcodebuild -configuration Release
-#    - name: test
-#      run: cd build && ctest
+        
+    - name: Collect artifact
+      uses: actions/upload-artifact@v4
+      if: steps.build.outcome == 'success' && always()
+      with:
+        name: Artifact
+        if-no-files-found: error
+        path: |
+          Build
+          Resources
+          libONI
+
+  deploy-mac:
+
+    needs: [build-mac]
+    runs-on: macos-latest
+    if: github.event_name == 'release' && always() && !failure() && !cancelled()
+
+    steps:
+
+    - name: Download build folder
+      uses: actions/download-artifact@v4
+      with:
+        name: Artifact
+
     - name: codesign_deploy
-      if: github.ref == 'refs/heads/main'
       env:
         ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
         MACOS_CERTIFICATE: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
@@ -41,8 +133,8 @@ jobs:
         build_dir: "Build/Release"
         package: AcquisitionBoard-mac
       run: |
-        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]" | tail -1)
-        tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
+        plugin_api=${{ needs.build-mac.outputs.PLUGIN_API }}
+        tag=${{ needs.build-mac.outputs.PLUGIN_VERSION }}
         new_plugin_ver=$tag-API$plugin_api
 
         mkdir plugins 

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -2,20 +2,86 @@ name: Windows
 
 on: 
   push:
+    branches: [main] # NB: Runs whenever a PR is merged to main
   pull_request:
+    branches: [main] # NB: Runs when a PR to main is opened. This can be expanded to run when PRs are opened to other branches (i.e., testing-juce8)
+  release:
+    types: [published] # NB: Runs whenever a new release is created. Releases are based on tags, but are separate in that a tag can be created without a concurrent release
 
 jobs:
 
+  check-semver:
+    runs-on: ubuntu-22.04
+    if: github.event_name != 'release'
+    steps:
+      - name: Checkout current version
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Find previous release
+        id: previous-release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          echo "RELEASE_NAME=$(gh release list -L 1 --json tagName -q .[0].tagName)" >> $GITHUB_OUTPUT
+          
+      - name: Checkout last release version
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.previous-release.outputs.RELEASE_NAME }}
+          path: last-release
+          sparse-checkout: |
+            Source/OpenEphysLib.cpp
+          sparse-checkout-cone-mode: false
+
+      - name: Extract Versions
+        id: extract-versions
+        run: |
+          ls -la
+          ls last-release -la
+          ls last-release/Source -la
+          cat ./last-release/Source/OpenEphysLib.cpp
+          echo "CURRENT_VERSION=$(cat ./Source/OpenEphysLib.cpp | grep -w -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> $GITHUB_OUTPUT
+          echo "PREVIOUS_VERSION=$(cat ./last-release/Source/OpenEphysLib.cpp | grep -w -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> $GITHUB_OUTPUT
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10.12"
+
+      - name: Install semver
+        run: python -m pip install semver
+
+      - name: Compare Versions
+        run: |
+         version_current=${{ steps.extract-versions.outputs.CURRENT_VERSION }}
+         version_release=${{ steps.extract-versions.outputs.PREVIOUS_VERSION }}
+ 
+         echo "Current Version: $version_current"
+         echo "Release Version: $version_release"
+         
+         if [ ! $(python -c "import semver; print(semver.compare(\"$version_current\", \"$version_release\"))") == 1 ]; then
+           echo "::error title=Invalid version number::Version number must be increased"
+           exit 1
+         fi
+
   build-windows:
 
+    needs: [check-semver]
+    if: always() && !failure() && !cancelled()
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [windows-latest]
+    outputs:
+      PLUGIN_API: ${{ steps.setup.outputs.PLUGIN_API }}
+      PLUGIN_VERSION: ${{ steps.setup.outputs.PLUGIN_VERSION }}
     
     steps:
     - uses: actions/checkout@v4
+
     - name: setup
+      id: setup
       run: |
         cd ../..
         git clone https://github.com/open-ephys/plugin-GUI.git --branch testing-juce8
@@ -24,31 +90,58 @@ jobs:
         mkdir Release && cd Release
         curl -L https://openephys.jfrog.io/artifactory/GUI-binaries/Libraries/open-ephys-lib-v1.0.0-alpha.zip --output open-ephys-lib.zip
         unzip open-ephys-lib.zip
+        echo "PLUGIN_API=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)" >> GITHUB_OUTPUT
+        echo "PLUGIN_VERSION=$(grep -w ../Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")" >> GITHUB_OUTPUT
       shell: bash
+      
     - name: configure
       run: |
         cd Build
         cmake -G "Visual Studio 17 2022" -A x64 .. 
       shell: bash
+
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v2
+
     - name: build-plugin
+      id: build-plugin
       run: |
         cd Build
         msbuild INSTALL.vcxproj -p:Configuration=Release -p:Platform=x64
       shell: cmd
-# TODO: Perform some basic testing before publishing...
-#    - name: test
-#      run: cd build && ctest
+      
+    - name: Collect artifact
+      uses: actions/upload-artifact@v4
+      if: steps.build-plugin.outcome == 'success' && always()
+      with:
+        name: Artifact
+        if-no-files-found: error
+        path: |
+          Build
+          Resources
+          libONI
+
+  deploy-windows:
+
+    needs: [build-windows]
+    runs-on: ubuntu-22.04
+    if: github.event_name == 'release' && always() && !failure() && !cancelled()
+
+    steps:
+
+    - name: Download build folder
+      uses: actions/download-artifact@v4
+      with:
+        name: Artifact
+
     - name: deploy
-      if: github.ref == 'refs/heads/main'
       env:
         ARTIFACTORY_ACCESS_TOKEN: ${{ secrets.ARTIFACTORY_ACCESS_TOKEN }}
         build_dir: "Build/Release"
         package: AcquisitionBoard-windows
       run: |
-        plugin_api=$(grep -rnw ../../plugin-GUI/Source -e '#define PLUGIN_API_VER' | grep -Eo "[0-9]*" | tail -1)
-        tag=$(grep -w Source/OpenEphysLib.cpp -e 'info->libVersion' | grep -Eo "[0-9]+.[0-9]+.[0-9]+")
+        plugin_api=${{ needs.build-windows.outputs.PLUGIN_API }}
+        tag=${{ needs.build-windows.outputs.PLUGIN_VERSION }}
         new_plugin_ver=$tag-API$plugin_api
         mkdir plugins
         cp $build_dir/*.dll plugins
@@ -59,4 +152,3 @@ jobs:
         powershell Compress-Archive -Path "plugins" -DestinationPath ${zipfile}
         powershell Compress-Archive -U -Path "shared" -DestinationPath ${zipfile}
         curl -H "X-JFrog-Art-Api:$ARTIFACTORY_ACCESS_TOKEN" -T $zipfile "https://openephys.jfrog.io/artifactory/AcquisitionBoard-plugin/windows/$zipfile"
-      shell: bash

--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "1.0.0";
+	info->libVersion = "1.0.1";
 	info->numPlugins = NUM_PLUGINS;
 }
 


### PR DESCRIPTION
This PR updates the workflows to use a different pattern than before. 

While this repo does not follow the exact pattern shown in the [github-actions](https://github.com/open-ephys/github-actions) repo, the README there does contain enough information to provide context for the current changes.

This change does require that the version number increase, but the changes will also not push to the remote server when the PR is merged. Actions will still run on pushes to main, but they will not actually upload the plugin. The only time that a plugin will be updated is if a new release is created.