### PR TITLE
Increase DataBuffer size to prevent buffer overflow in ONI boards

### DIFF
--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "1.1.1";
+	info->libVersion = "1.1.2";
 	info->numPlugins = NUM_PLUGINS;
 }
 

--- a/Source/devices/AcquisitionBoard.h
+++ b/Source/devices/AcquisitionBoard.h
@@ -204,7 +204,7 @@ public:
 
     DataBuffer* getBuffer()
     {
-        buffer = new DataBuffer (getNumChannels(), 10000);
+        buffer = new DataBuffer (getNumChannels(), 60000);
         return buffer;
     }
 

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -213,7 +213,7 @@ void AcqBoardONI::updateCustomStreams (OwnedArray<DataStream>& otherStreams, Own
     {
         //Memory usage device
         DataStream::Settings memStreamSettings {
-            "Memory Usage",
+            "memory_usage",
             "Hardware buffer usage on an acquisition board",
             "acq-board.memory",
             MEMORY_MONITOR_FS,
@@ -243,7 +243,7 @@ void AcqBoardONI::updateCustomStreams (OwnedArray<DataStream>& otherStreams, Own
         if (hasBNO[k])
         {
             DataStream::Settings bnoStreamSettings {
-                "IMU Port " + String::charToString (port[k]),
+                "IMU_port_" + String::charToString (port[k]),
                 "Inertial measurement unit data from the BNO device on port " + String::charToString (port[k]),
                 "acq-board.9dof",
                 100,


### PR DESCRIPTION
* Increased the buffer size from `10000` to `60000`

* Renamed the "Memory Usage" stream to "memory_usage" and "IMU Port X" to "IMU_port_X" for standardization.