### PR TITLE
Fix delay calculation when changing sample rate not triggering 

### DIFF
--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "1.1.4";
+	info->libVersion = "1.1.5";
 	info->numPlugins = NUM_PLUGINS;
 }
 

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -429,7 +429,7 @@ bool AcqBoardONI::initializeBoardInThread()
     //  - disables all DACs and sets gain to 0
     LOGDD ("DBG: 1");
 
-    setSampleRate (30000);
+    setSampleRate (30000, false);
 
     LOGDD ("DBG: A");
     evalBoard->setCableLengthMeters (Rhd2000ONIBoard::PortA, settings.cableLength.portA);
@@ -1022,7 +1022,7 @@ void AcqBoardONI::scanPortsInThread()
 
     float currentSampleRate = settings.boardSampleRate;
 
-    setSampleRate (30000); // set to 30 kHz temporarily
+    setSampleRate (30000, false); // set to 30 kHz temporarily
 
     LOGDD ("DBG: SC");
     // Enable all data streams, and set sources to cover one or two chips

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -429,7 +429,6 @@ bool AcqBoardONI::initializeBoardInThread()
     //  - disables all DACs and sets gain to 0
     LOGDD ("DBG: 1");
 
-    checkCableDelays = false;
     setSampleRate (30000);
 
     LOGDD ("DBG: A");
@@ -521,7 +520,12 @@ Array<int> AcqBoardONI::getAvailableSampleRates()
     return sampleRates;
 }
 
-void AcqBoardONI::setSampleRate (int desiredSampleRate)
+void AcqBoardONI::setSampleRate(int desiredSampleRate)
+{
+    setSampleRate (desiredSampleRate, true);
+}
+
+void AcqBoardONI::setSampleRate (int desiredSampleRate, bool reScanDelays)
 {
     Rhd2000ONIBoard::AmplifierSampleRate sampleRate;
 
@@ -614,7 +618,7 @@ void AcqBoardONI::setSampleRate (int desiredSampleRate)
     }
     LOGD ("Sample rate set to ", evalBoard->getSampleRate());
 
-    if (checkCableDelays)
+    if (reScanDelays)
     {
         checkAllCableDelays();
     }
@@ -1018,7 +1022,6 @@ void AcqBoardONI::scanPortsInThread()
 
     float currentSampleRate = settings.boardSampleRate;
 
-    checkCableDelays = false;
     setSampleRate (30000); // set to 30 kHz temporarily
 
     LOGDD ("DBG: SC");
@@ -1225,8 +1228,7 @@ void AcqBoardONI::scanPortsInThread()
     LOGD ("Set optimum delay for port C: ", settings.optimumDelay.portC);
     LOGD ("Set optimum delay for port D: ", settings.optimumDelay.portD);
 
-    checkCableDelays = ! initialScan;
-    setSampleRate (currentSampleRate); // restore saved sample rate and check delays
+    setSampleRate (currentSampleRate, !initialScan); // restore saved sample rate and check delays
 
     initialScan = false;
 }

--- a/Source/devices/oni/AcqBoardONI.h
+++ b/Source/devices/oni/AcqBoardONI.h
@@ -126,7 +126,7 @@ public:
     Array<int> getAvailableSampleRates();
 
     /** Set sample rate */
-    void setSampleRate (int sampleRateHz);
+    void setSampleRate (int sampleRateHz) override;
 
     /** Get current sample rate */
     float getSampleRate() const;
@@ -245,6 +245,9 @@ public:
     bool getMemoryMonitorSupport() const;
 
 private:
+    /** Sets sample rate and updates delays*/
+    void setSampleRate (int sampleRateHz, bool reScanDelays);
+
     /**Check board memory status */
     bool checkBoardMem() const;
 
@@ -325,9 +328,6 @@ private:
 
     /** Lock for interacting with board */
     CriticalSection oniLock;
-
-    /** Re-check cable delays after changing sample rate*/
-    bool checkCableDelays = false;
 
     /** Hold the current device ID.Used to determine which version of the acquisition board this is */
     int deviceId = 0;


### PR DESCRIPTION
This fixes an issue when changing sample rate after initial scan did not trigger the delay calculation unless the manual rescan button was pressed. This caused channels sometimes being wrong when setting a low sample rate if manual rescan was not pressed.