### PR TITLE
Fix potential crashes

### DIFF
--- a/Source/OpenEphysLib.cpp
+++ b/Source/OpenEphysLib.cpp
@@ -41,7 +41,7 @@ extern "C" EXPORT void getLibInfo(Plugin::LibraryInfo* info)
 {
 	info->apiVersion = PLUGIN_API_VER;
 	info->name = "Acquisition Board";
-	info->libVersion = "1.1.5";
+	info->libVersion = "1.1.6";
 	info->numPlugins = NUM_PLUGINS;
 }
 

--- a/Source/devices/oni/AcqBoardONI.cpp
+++ b/Source/devices/oni/AcqBoardONI.cpp
@@ -27,6 +27,8 @@
 #include <string>
 
 #define INIT_STEP 64
+//#define DEBUG_EMULATE_HEADSTAGES 8
+//#define DEBUG_EMULATE_64CH
 
 AcqBoardONI::AcqBoardONI() : AcquisitionBoard(),
                              chipRegisters (30000.0f)
@@ -899,6 +901,7 @@ int AcqBoardONI::getIntanChipId (
     // This is just used to verify that we are getting good data over the SPI
     // communication channel.
     intanChipPresent = ((char) dataBlock->auxiliaryData[stream][2][32] == 'I' && (char) dataBlock->auxiliaryData[stream][2][33] == 'N' && (char) dataBlock->auxiliaryData[stream][2][34] == 'T' && (char) dataBlock->auxiliaryData[stream][2][35] == 'A' && (char) dataBlock->auxiliaryData[stream][2][36] == 'N' && (char) dataBlock->auxiliaryData[stream][2][24] == 'R' && (char) dataBlock->auxiliaryData[stream][2][25] == 'H' && (char) dataBlock->auxiliaryData[stream][2][26] == 'D');
+    //std::cout << (char) dataBlock->auxiliaryData[stream][2][32] << "-" << (char) dataBlock->auxiliaryData[stream][2][33] << "-" << (char) dataBlock->auxiliaryData[stream][2][34] << std::endl;
 
     // If the SPI communication is bad, return -1.  Otherwise, return the Intan
     // chip ID number stored in ROM register 63.
@@ -936,7 +939,6 @@ void AcqBoardONI::scanPortsInThread()
     if (! checkBoardMem())
         return;
     LOGDD ("DBG: SA");
-
     if (hasI2cSupport)
     {
         bool enableI2c[NUMBER_OF_PORTS] = { true, true, true, true };
@@ -1104,7 +1106,7 @@ void AcqBoardONI::scanPortsInThread()
         {
             id = getIntanChipId (dataBlock.get(), hs, register59Value);
 
-            //     LOGD("hs ", hs, " id ", id, " r59 ", (int)register59Value);
+                // LOGD("hs ", hs, " id ", id, " r59 ", (int)register59Value);
 
             if (id == CHIP_ID_RHD2132 || id == CHIP_ID_RHD2216 || (id == CHIP_ID_RHD2164 && register59Value == REGISTER_59_MISO_A))
             {
@@ -1322,6 +1324,7 @@ void AcqBoardONI::updateBoardStreams()
             evalBoard->enableDataStream (i, false);
         }
     }
+    evalBoard->updateStreamBlockSize();
 }
 
 bool AcqBoardONI::isHeadstageEnabled (int hsNum) const
@@ -1719,6 +1722,8 @@ void AcqBoardONI::run()
             {
                 LOGE ("Error reading ONI frame: ", oni_error_str (res), " code ", res);
                 signalThreadShouldExit();
+                oni_destroy_frame (frame);
+                continue;
             }
             if (frame->dev_idx == Rhd2000ONIBoard::DEVICE_RHYTHM)
             {

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.cpp
@@ -1408,3 +1408,23 @@ void Rhd2000ONIBoard::setBnoAxisMap (const uint32_t port, int axisMap)
 
     oni_write_reg (ctx, device, (uint32_t) BnoRegisters::AXIS_MAP, axisMap);
 }
+
+
+void Rhd2000ONIBoard::debug_printDevTable() const
+{
+    oni_size_t tableSize;
+    size_t optSize = sizeof (tableSize);
+    oni_get_opt (ctx, ONI_OPT_NUMDEVICES, &tableSize, &optSize);
+    optSize = sizeof (oni_device_t) * tableSize;
+    oni_device_t* devs = (oni_device_t*)malloc(optSize);
+    if (devs == NULL)
+        return;
+
+    oni_get_opt (ctx, ONI_OPT_DEVICETABLE, devs, &optSize);
+    for (int i = 0; i < tableSize; i++)
+    {
+        printf ("N: %d Idx %x Id %x Ver: %x Rd %x Wr %x\n", i, devs[i].idx, devs[i].id, devs[i].version, devs[i].read_size, devs[i].write_size);
+    }
+
+    free (devs);
+}

--- a/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
+++ b/Source/devices/oni/rhythm-api/rhd2000ONIboard.h
@@ -179,6 +179,8 @@ public:
 
     uint32_t getDeviceIdOnEeprom (const uint32_t);
 
+    void debug_printDevTable() const;
+
     enum BoardMemState
     {
         BOARDMEM_INIT = 0,


### PR DESCRIPTION
- Fix issue where frame size wasn't properly updated, causing issues with more than 256 channels
- Fix read error handling not exiting at the apropriate time
- Add debug method to the library to print device table, for future debug needs